### PR TITLE
feat: localize admin dashboard

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,18 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import en from "./locales/en";
+import fr from "./locales/fr";
+
+i18n.use(initReactI18next).init({
+  resources: {
+    en: { translation: en },
+    fr: { translation: fr },
+  },
+  lng: "fr",
+  fallbackLng: "en",
+  interpolation: {
+    escapeValue: false,
+  },
+});
+
+export default i18n;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,0 +1,37 @@
+export default {
+  admin: {
+    dashboard: {
+      title: "Admin Panel",
+      subtitle: "Manage ManaShop stores",
+      stats: {
+        totalUsers: "Total Users",
+        creators: "Creators",
+        productsServices: "Products & Services",
+        totalRevenue: "Total Revenue"
+      },
+      recentOrders: {
+        title: "Recent Orders",
+        viewAll: "View All",
+        none: "No recent orders",
+        order: "Order #{{id}}",
+        items_one: "{{count}} item",
+        items_other: "{{count}} items"
+      },
+      quickActions: {
+        title: "Quick Actions",
+        manageUsers: {
+          title: "Manage Users",
+          description: "View and edit user profiles"
+        },
+        moderateContent: {
+          title: "Moderate Content",
+          description: "Review and approve products"
+        },
+        reports: {
+          title: "Reports",
+          description: "Analyze performance"
+        }
+      }
+    }
+  }
+};

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -1,0 +1,37 @@
+export default {
+  admin: {
+    dashboard: {
+      title: "Admin Panel",
+      subtitle: "Gestion des boutiques ManaShop",
+      stats: {
+        totalUsers: "Utilisateurs totaux",
+        creators: "Créateurs",
+        productsServices: "Produits & Services",
+        totalRevenue: "Revenus totaux"
+      },
+      recentOrders: {
+        title: "Commandes Récentes",
+        viewAll: "Voir toutes",
+        none: "Aucune commande récente",
+        order: "Commande #{{id}}",
+        items_one: "{{count}} article",
+        items_other: "{{count}} articles"
+      },
+      quickActions: {
+        title: "Actions Rapides",
+        manageUsers: {
+          title: "Gérer les Utilisateurs",
+          description: "Voir et modifier les profils utilisateurs"
+        },
+        moderateContent: {
+          title: "Modérer le Contenu",
+          description: "Examiner et approuver les produits"
+        },
+        reports: {
+          title: "Rapports",
+          description: "Analyser les performances"
+        }
+      }
+    }
+  }
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import './i18n';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/Admin/AdminDashboard.tsx
+++ b/src/pages/Admin/AdminDashboard.tsx
@@ -12,6 +12,7 @@ import {
 import { LoadingSpinner } from "../../components/UI/LoadingSpinner";
 import { Card, CardHeader, CardContent } from "../../components/UI/Card";
 import { Button } from "../../components/UI/Button";
+import { t } from "i18next";
 
 export function AdminDashboard() {
   const [stats, setStats] = useState({
@@ -85,10 +86,10 @@ export function AdminDashboard() {
           </div>
           <div>
             <h1 className="text-4xl md:text-5xl font-light text-foreground tracking-tight">
-              Admin Panel
+              {t("admin.dashboard.title")}
             </h1>
             <p className="text-muted-foreground/70 text-lg">
-              Gestion des boutiques ManaShop
+              {t("admin.dashboard.subtitle")}
             </p>
           </div>
         </div>
@@ -104,7 +105,7 @@ export function AdminDashboard() {
             {stats.totalUsers.toLocaleString()}
           </div>
           <div className="text-muted-foreground/70 text-sm">
-            Utilisateurs totaux
+            {t("admin.dashboard.stats.totalUsers")}
           </div>
         </Card>
 
@@ -115,7 +116,9 @@ export function AdminDashboard() {
           <div className="text-3xl font-light text-foreground mb-2">
             {stats.totalCreators.toLocaleString()}
           </div>
-          <div className="text-muted-foreground/70 text-sm">Créateurs</div>
+          <div className="text-muted-foreground/70 text-sm">
+            {t("admin.dashboard.stats.creators")}
+          </div>
         </Card>
 
         <Card className="text-center p-6">
@@ -126,7 +129,7 @@ export function AdminDashboard() {
             {(stats.totalProducts + stats.totalServices).toLocaleString()}
           </div>
           <div className="text-muted-foreground/70 text-sm">
-            Produits & Services
+            {t("admin.dashboard.stats.productsServices")}
           </div>
         </Card>
 
@@ -137,7 +140,9 @@ export function AdminDashboard() {
           <div className="text-3xl font-light text-foreground mb-2">
             ${stats.totalRevenue.toLocaleString()}
           </div>
-          <div className="text-muted-foreground/70 text-sm">Revenus totaux</div>
+          <div className="text-muted-foreground/70 text-sm">
+            {t("admin.dashboard.stats.totalRevenue")}
+          </div>
         </Card>
       </div>
 
@@ -145,10 +150,10 @@ export function AdminDashboard() {
       <div className="mb-12">
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-2xl font-light text-foreground tracking-tight">
-            Commandes Récentes
+            {t("admin.dashboard.recentOrders.title")}
           </h2>
           <Button variant="outline" size="sm">
-            Voir toutes
+            {t("admin.dashboard.recentOrders.viewAll")}
           </Button>
         </div>
 
@@ -157,7 +162,7 @@ export function AdminDashboard() {
             <Card className="text-center p-12">
               <Package className="h-16 w-16 text-muted-foreground/40 mx-auto mb-4" />
               <p className="text-muted-foreground/70">
-                Aucune commande récente
+                {t("admin.dashboard.recentOrders.none")}
               </p>
             </Card>
           ) : (
@@ -166,7 +171,7 @@ export function AdminDashboard() {
                 <div className="flex items-center justify-between">
                   <div>
                     <h3 className="text-lg font-light text-foreground">
-                      Commande #{order.id.slice(-8)}
+                      {t("admin.dashboard.recentOrders.order", { id: order.id.slice(-8) })}
                     </h3>
                     <p className="text-muted-foreground/70 text-sm">
                       {new Date(order.created_at).toLocaleDateString("fr-FR", {
@@ -178,8 +183,9 @@ export function AdminDashboard() {
                       })}
                     </p>
                     <p className="text-muted-foreground/70 text-sm">
-                      {order.order_items?.length || 0} article
-                      {order.order_items?.length > 1 ? "s" : ""}
+                      {t("admin.dashboard.recentOrders.items", {
+                        count: order.order_items?.length || 0,
+                      })}
                     </p>
                   </div>
                   <div className="text-right">
@@ -200,7 +206,7 @@ export function AdminDashboard() {
       {/* Quick Actions */}
       <div>
         <h2 className="text-2xl font-light text-foreground tracking-tight mb-6">
-          Actions Rapides
+          {t("admin.dashboard.quickActions.title")}
         </h2>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -209,10 +215,10 @@ export function AdminDashboard() {
               <Users className="h-8 w-8 text-primary" />
             </div>
             <h3 className="text-lg font-light text-foreground mb-2">
-              Gérer les Utilisateurs
+              {t("admin.dashboard.quickActions.manageUsers.title")}
             </h3>
             <p className="text-muted-foreground/70 text-sm">
-              Voir et modifier les profils utilisateurs
+              {t("admin.dashboard.quickActions.manageUsers.description")}
             </p>
           </Card>
 
@@ -221,10 +227,10 @@ export function AdminDashboard() {
               <Package className="h-8 w-8 text-primary" />
             </div>
             <h3 className="text-lg font-light text-foreground mb-2">
-              Modérer le Contenu
+              {t("admin.dashboard.quickActions.moderateContent.title")}
             </h3>
             <p className="text-muted-foreground/70 text-sm">
-              Examiner et approuver les produits
+              {t("admin.dashboard.quickActions.moderateContent.description")}
             </p>
           </Card>
 
@@ -233,10 +239,10 @@ export function AdminDashboard() {
               <TrendingUp className="h-8 w-8 text-primary" />
             </div>
             <h3 className="text-lg font-light text-foreground mb-2">
-              Rapports
+              {t("admin.dashboard.quickActions.reports.title")}
             </h3>
             <p className="text-muted-foreground/70 text-sm">
-              Analyser les performances
+              {t("admin.dashboard.quickActions.reports.description")}
             </p>
           </Card>
         </div>


### PR DESCRIPTION
## Summary
- add i18n setup with English and French locales
- translate Admin Dashboard strings to use `t` keys

## Testing
- `npm test`
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*


------
https://chatgpt.com/codex/tasks/task_e_68ba6921b478832688d7d42960fbb85a