### PR TITLE
feat: add translations for notification test

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,18 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from '../locales/en';
+import fr from '../locales/fr';
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      fr: { translation: fr },
+    },
+    lng: 'fr',
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false },
+  });
+
+export default i18n;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,0 +1,36 @@
+export default {
+  notificationTest: {
+    title: "Notifications Test",
+    description: "Development page to test MTG Artisan's notification system.",
+    architecture: {
+      title: "System Architecture",
+      dbTables: {
+        title: "📊 Database Tables",
+        notificationEvents: "Incoming events queue",
+        notifications: "Notifications created for users",
+        notificationPreferences: "User preferences",
+        notificationDeliveries: "Delivery tasks (email, push, etc.)",
+        notificationTemplates: "Message templates"
+      },
+      supabaseFunctions: {
+        title: "⚙️ Supabase Functions",
+        eventsEmit: "Emits an event",
+        eventsFanout: "Processes events into notifications",
+        notificationsRead: "Marks as read",
+        notificationsSeen: "Marks as seen",
+        preferences: "Manages preferences"
+      },
+      dataFlow: {
+        title: "🔄 Data Flow",
+        step1: "The application emits an event via",
+        step2: "The event is stored in",
+        step3Before: "The function",
+        step3After: "processes the events",
+        step4: "Notifications are created in",
+        step5Before: "Delivery tasks are created in",
+        step6: "The React interface subscribes to real-time changes",
+        step7: "Notifications appear in the bell and as toasts"
+      }
+    }
+  }
+};

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -1,0 +1,36 @@
+export default {
+  notificationTest: {
+    title: "Test des Notifications",
+    description: "Page de développement pour tester le système de notifications de MTG Artisan.",
+    architecture: {
+      title: "Architecture du Système",
+      dbTables: {
+        title: "📊 Tables de Base de Données",
+        notificationEvents: "Queue d'événements entrants",
+        notifications: "Notifications créées pour les utilisateurs",
+        notificationPreferences: "Préférences utilisateur",
+        notificationDeliveries: "Tâches de livraison (email, push, etc.)",
+        notificationTemplates: "Templates de messages"
+      },
+      supabaseFunctions: {
+        title: "⚙️ Fonctions Supabase",
+        eventsEmit: "Émet un événement",
+        eventsFanout: "Traite les événements en notifications",
+        notificationsRead: "Marque comme lu",
+        notificationsSeen: "Marque comme vu",
+        preferences: "Gère les préférences"
+      },
+      dataFlow: {
+        title: "🔄 Flux de Données",
+        step1: "L'application émet un événement via",
+        step2: "L'événement est stocké dans",
+        step3Before: "La fonction",
+        step3After: "traite les événements",
+        step4: "Les notifications sont créées dans",
+        step5Before: "Les tâches de livraison sont créées dans",
+        step6: "L'interface React s'abonne aux changements en temps réel",
+        step7: "Les notifications apparaissent dans la cloche et comme toasts"
+      }
+    }
+  }
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import './lib/i18n';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/NotificationTest.tsx
+++ b/src/pages/NotificationTest.tsx
@@ -1,16 +1,18 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { NotificationTester } from "../components/Notifications/NotificationTester";
 
 export function NotificationTest() {
+  const { t } = useTranslation();
+
   return (
     <div className="max-w-6xl mx-auto p-6">
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-foreground mb-2">
-          Test des Notifications
+          {t("notificationTest.title")}
         </h1>
         <p className="text-muted-foreground">
-          Page de développement pour tester le système de notifications de MTG
-          Artisan.
+          {t("notificationTest.description")}
         </p>
       </div>
 
@@ -18,56 +20,72 @@ export function NotificationTest() {
 
       <div className="mt-8 p-6 bg-card border border-border rounded-lg">
         <h2 className="text-xl font-semibold text-foreground mb-4">
-          Architecture du Système
+          {t("notificationTest.architecture.title")}
         </h2>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
             <h3 className="font-medium text-foreground mb-3">
-              📊 Tables de Base de Données
+              {t("notificationTest.architecture.dbTables.title")}
             </h3>
             <ul className="text-sm text-muted-foreground space-y-1">
               <li>
-                • <code>notification_events</code> - Queue d'événements entrants
+                • <code>notification_events</code> -
+                {" "}
+                {t("notificationTest.architecture.dbTables.notificationEvents")}
               </li>
               <li>
-                • <code>notifications</code> - Notifications créées pour les
-                utilisateurs
+                • <code>notifications</code> -
+                {" "}
+                {t("notificationTest.architecture.dbTables.notifications")}
               </li>
               <li>
-                • <code>notification_preferences</code> - Préférences
-                utilisateur
+                • <code>notification_preferences</code> -
+                {" "}
+                {t("notificationTest.architecture.dbTables.notificationPreferences")}
               </li>
               <li>
-                • <code>notification_deliveries</code> - Tâches de livraison
-                (email, push, etc.)
+                • <code>notification_deliveries</code> -
+                {" "}
+                {t("notificationTest.architecture.dbTables.notificationDeliveries")}
               </li>
               <li>
-                • <code>notification_templates</code> - Templates de messages
+                • <code>notification_templates</code> -
+                {" "}
+                {t("notificationTest.architecture.dbTables.notificationTemplates")}
               </li>
             </ul>
           </div>
 
           <div>
             <h3 className="font-medium text-foreground mb-3">
-              ⚙️ Fonctions Supabase
+              {t("notificationTest.architecture.supabaseFunctions.title")}
             </h3>
             <ul className="text-sm text-muted-foreground space-y-1">
               <li>
-                • <code>events-emit</code> - Émet un événement
+                • <code>events-emit</code> -
+                {" "}
+                {t("notificationTest.architecture.supabaseFunctions.eventsEmit")}
               </li>
               <li>
-                • <code>events-fanout</code> - Traite les événements en
-                notifications
+                • <code>events-fanout</code> -
+                {" "}
+                {t("notificationTest.architecture.supabaseFunctions.eventsFanout")}
               </li>
               <li>
-                • <code>notifications-read</code> - Marque comme lu
+                • <code>notifications-read</code> -
+                {" "}
+                {t("notificationTest.architecture.supabaseFunctions.notificationsRead")}
               </li>
               <li>
-                • <code>notifications-seen</code> - Marque comme vu
+                • <code>notifications-seen</code> -
+                {" "}
+                {t("notificationTest.architecture.supabaseFunctions.notificationsSeen")}
               </li>
               <li>
-                • <code>preferences</code> - Gère les préférences
+                • <code>preferences</code> -
+                {" "}
+                {t("notificationTest.architecture.supabaseFunctions.preferences")}
               </li>
             </ul>
           </div>
@@ -75,30 +93,32 @@ export function NotificationTest() {
 
         <div className="mt-6 p-4 bg-muted/30 border border-border rounded-lg">
           <h4 className="font-medium text-foreground text-sm mb-2">
-            🔄 Flux de Données
+            {t("notificationTest.architecture.dataFlow.title")}
           </h4>
           <ol className="text-xs text-muted-foreground space-y-1">
             <li>
-              1. L'application émet un événement via{" "}
+              1. {t("notificationTest.architecture.dataFlow.step1")} {" "}
               <code>NotificationService.emitEvent()</code>
             </li>
             <li>
-              2. L'événement est stocké dans <code>notification_events</code>
+              2. {t("notificationTest.architecture.dataFlow.step2")} {" "}
+              <code>notification_events</code>
             </li>
             <li>
-              3. La fonction <code>events-fanout</code> traite les événements
+              3. {t("notificationTest.architecture.dataFlow.step3Before")} {" "}
+              <code>events-fanout</code> {" "}
+              {t("notificationTest.architecture.dataFlow.step3After")}
             </li>
             <li>
-              4. Les notifications sont créées dans <code>notifications</code>
+              4. {t("notificationTest.architecture.dataFlow.step4")} {" "}
+              <code>notifications</code>
             </li>
             <li>
-              5. Les tâches de livraison sont créées dans{" "}
+              5. {t("notificationTest.architecture.dataFlow.step5Before")} {" "}
               <code>notification_deliveries</code>
             </li>
-            <li>6. L'interface React s'abonne aux changements en temps réel</li>
-            <li>
-              7. Les notifications apparaissent dans la cloche et comme toasts
-            </li>
+            <li>6. {t("notificationTest.architecture.dataFlow.step6")}</li>
+            <li>7. {t("notificationTest.architecture.dataFlow.step7")}</li>
           </ol>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace hardcoded NotificationTest copy with translation keys
- add English and French translations and i18n setup

## Testing
- `npm test`
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_68ba6928688883269282c3747f4936fa