### PR TITLE
feat: translate notification tester components

### DIFF
--- a/src/components/Notifications/NotificationTester.tsx
+++ b/src/components/Notifications/NotificationTester.tsx
@@ -3,130 +3,131 @@ import { Play, Send, User, Package, Star, MessageSquare, Settings, AlertTriangle
 import { NotificationService } from '../../services/notificationService';
 import { useAuth } from '../../contexts/AuthContext';
 import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
 
 const TEST_EVENTS = [
   {
-    category: 'Commandes',
+    categoryKey: 'notificationTester.categories.orders',
     icon: Package,
     color: 'text-blue-500',
     events: [
       {
         name: 'order.paid',
-        label: 'Commande payée',
-        description: 'Simuler une commande payée avec succès',
+        labelKey: 'notificationTester.events.orderPaid.label',
+        descriptionKey: 'notificationTester.events.orderPaid.description',
         payload: { orderId: 'ORD-123', total: 89.99, currency: 'EUR', buyerName: 'Alice Dupont' }
       },
       {
         name: 'order.shipped',
-        label: 'Commande expédiée',
-        description: 'Simuler l\'expédition d\'une commande',
+        labelKey: 'notificationTester.events.orderShipped.label',
+        descriptionKey: 'notificationTester.events.orderShipped.description',
         payload: { orderId: 'ORD-123', trackingNumber: 'FR123456789', shopName: 'ArtMaster Studio' }
       },
       {
         name: 'alter.commissioned',
-        label: 'Alter commandé',
-        description: 'Simuler la commande d\'un alter MTG',
+        labelKey: 'notificationTester.events.alterCommissioned.label',
+        descriptionKey: 'notificationTester.events.alterCommissioned.description',
         payload: { cardName: 'Lightning Bolt', artistName: 'Marie Artisan', orderId: 'ALT-456' }
       },
       {
         name: 'token.ready',
-        label: 'Tokens prêts',
-        description: 'Simuler des tokens personnalisés prêts',
+        labelKey: 'notificationTester.events.tokenReady.label',
+        descriptionKey: 'notificationTester.events.tokenReady.description',
         payload: { tokenName: 'Goblin Token Set', orderId: 'TOK-789' }
       }
     ]
   },
   {
-    category: 'Services',
+    categoryKey: 'notificationTester.categories.services',
     icon: User,
     color: 'text-green-500',
     events: [
       {
         name: 'coaching.scheduled',
-        label: 'Coaching programmé',
-        description: 'Simuler une session de coaching programmée',
+        labelKey: 'notificationTester.events.coachingScheduled.label',
+        descriptionKey: 'notificationTester.events.coachingScheduled.description',
         payload: { coachName: 'Pro Player', date: '2024-02-15', time: '19:00' }
       },
       {
         name: 'deckbuilding.completed',
-        label: 'Deck terminé',
-        description: 'Simuler un deck construit terminé',
+        labelKey: 'notificationTester.events.deckbuildingCompleted.label',
+        descriptionKey: 'notificationTester.events.deckbuildingCompleted.description',
         payload: { format: 'Modern Burn', builderName: 'DeckMaster', orderId: 'DECK-321' }
       }
     ]
   },
   {
-    category: 'Messages',
+    categoryKey: 'notificationTester.categories.messages',
     icon: MessageSquare,
     color: 'text-purple-500',
     events: [
       {
         name: 'message.new',
-        label: 'Nouveau message',
-        description: 'Simuler un nouveau message reçu',
+        labelKey: 'notificationTester.events.messageNew.label',
+        descriptionKey: 'notificationTester.events.messageNew.description',
         payload: { senderName: 'Bob Collectionneur' }
       },
       {
         name: 'message.commission_request',
-        label: 'Demande de commission',
-        description: 'Simuler une demande de commission personnalisée',
+        labelKey: 'notificationTester.events.messageCommissionRequest.label',
+        descriptionKey: 'notificationTester.events.messageCommissionRequest.description',
         payload: { buyerName: 'Sarah Magic' }
       }
     ]
   },
   {
-    category: 'Avis',
+    categoryKey: 'notificationTester.categories.reviews',
     icon: Star,
     color: 'text-yellow-500',
     events: [
       {
         name: 'review.posted',
-        label: 'Nouvel avis',
-        description: 'Simuler un nouvel avis client',
+        labelKey: 'notificationTester.events.reviewPosted.label',
+        descriptionKey: 'notificationTester.events.reviewPosted.description',
         payload: { reviewerName: 'Client Satisfait', rating: 5, productName: 'Alter Lightning Bolt' }
       }
     ]
   },
   {
-    category: 'Boutique',
+    categoryKey: 'notificationTester.categories.shop',
     icon: Settings,
     color: 'text-orange-500',
     events: [
       {
         name: 'shop.verified',
-        label: 'Boutique vérifiée',
-        description: 'Simuler la vérification d\'une boutique',
+        labelKey: 'notificationTester.events.shopVerified.label',
+        descriptionKey: 'notificationTester.events.shopVerified.description',
         payload: { shopName: 'Mon Atelier MTG' }
       },
       {
         name: 'product.low_stock',
-        label: 'Stock faible',
-        description: 'Simuler une alerte de stock faible',
+        labelKey: 'notificationTester.events.productLowStock.label',
+        descriptionKey: 'notificationTester.events.productLowStock.description',
         payload: { productName: 'Playmat Dragon', stock: 2 }
       },
       {
         name: 'payout.completed',
-        label: 'Paiement reçu',
-        description: 'Simuler un paiement reçu',
-        payload: { amount: 250.50, currency: 'EUR' }
+        labelKey: 'notificationTester.events.payoutCompleted.label',
+        descriptionKey: 'notificationTester.events.payoutCompleted.description',
+        payload: { amount: 250.5, currency: 'EUR' }
       }
     ]
   },
   {
-    category: 'Système',
+    categoryKey: 'notificationTester.categories.system',
     icon: AlertTriangle,
     color: 'text-red-500',
     events: [
       {
         name: 'system.update',
-        label: 'Mise à jour système',
-        description: 'Simuler une notification de mise à jour',
+        labelKey: 'notificationTester.events.systemUpdate.label',
+        descriptionKey: 'notificationTester.events.systemUpdate.description',
         payload: {}
       },
       {
         name: 'account.login_new_device',
-        label: 'Nouvelle connexion',
-        description: 'Simuler une connexion depuis un nouvel appareil',
+        labelKey: 'notificationTester.events.accountLoginNewDevice.label',
+        descriptionKey: 'notificationTester.events.accountLoginNewDevice.description',
         payload: { device: 'iPhone 15', location: 'Paris, France' }
       }
     ]
@@ -136,15 +137,16 @@ const TEST_EVENTS = [
 export function NotificationTester() {
   const { user } = useAuth();
   const [isLoading, setIsLoading] = useState<string | null>(null);
+  const { t } = useTranslation();
 
   if (!user) {
     return (
       <div className="p-6 bg-card border border-border rounded-lg">
         <h3 className="text-lg font-semibold text-foreground mb-2">
-          Testeur de Notifications
+          {t('notificationTester.noUser.title')}
         </h3>
         <p className="text-muted-foreground">
-          Vous devez être connecté pour tester les notifications.
+          {t('notificationTester.noUser.message')}
         </p>
       </div>
     );
@@ -152,14 +154,14 @@ export function NotificationTester() {
 
   const handleSendNotification = async (eventName: string, payload: any) => {
     if (!user?.id) return;
-    
+
     setIsLoading(eventName);
     try {
       await NotificationService.emitEvent(eventName, [user.id], payload);
-      toast.success(`Notification "${eventName}" envoyée avec succès !`);
+      toast.success(t('notificationTester.toast.success', { eventName }));
     } catch (error) {
-      console.error('Erreur lors de l\'envoi de la notification:', error);
-      toast.error('Erreur lors de l\'envoi de la notification');
+      console.error('Error sending notification:', error);
+      toast.error(t('notificationTester.toast.error'));
     } finally {
       setIsLoading(null);
     }
@@ -170,22 +172,21 @@ export function NotificationTester() {
       <div className="mb-6">
         <h3 className="text-lg font-semibold text-foreground mb-2 flex items-center space-x-2">
           <Play className="w-5 h-5 text-primary" />
-          <span>Testeur de Notifications MTG Artisan</span>
+          <span>{t('notificationTester.header.title')}</span>
         </h3>
         <p className="text-muted-foreground text-sm">
-          Testez les différents types de notifications de l'application. 
-          Les notifications apparaîtront dans la cloche en haut à droite et comme toast.
+          {t('notificationTester.header.description')}
         </p>
       </div>
 
       <div className="space-y-6">
         {TEST_EVENTS.map((category) => (
-          <div key={category.category} className="space-y-3">
+          <div key={category.categoryKey} className="space-y-3">
             <h4 className="font-medium text-foreground flex items-center space-x-2">
               <category.icon className={`w-4 h-4 ${category.color}`} />
-              <span>{category.category}</span>
+              <span>{t(category.categoryKey)}</span>
             </h4>
-            
+
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               {category.events.map((event) => (
                 <div
@@ -195,21 +196,21 @@ export function NotificationTester() {
                   <div className="flex items-start justify-between">
                     <div className="flex-1">
                       <h5 className="font-medium text-foreground text-sm">
-                        {event.label}
+                        {t(event.labelKey)}
                       </h5>
                       <p className="text-xs text-muted-foreground mt-1">
-                        {event.description}
+                        {t(event.descriptionKey)}
                       </p>
                       <code className="text-xs text-primary bg-primary/10 px-2 py-1 rounded mt-2 inline-block">
                         {event.name}
                       </code>
                     </div>
-                    
+
                     <button
                       onClick={() => handleSendNotification(event.name, event.payload)}
                       disabled={isLoading === event.name}
                       className="ml-3 p-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                      title="Envoyer cette notification"
+                      title={t('notificationTester.sendButton.title')}
                     >
                       {isLoading === event.name ? (
                         <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
@@ -226,13 +227,25 @@ export function NotificationTester() {
       </div>
 
       <div className="mt-6 p-4 bg-muted/30 border border-border rounded-lg">
-        <h5 className="font-medium text-foreground text-sm mb-2">💡 Instructions</h5>
+        <h5 className="font-medium text-foreground text-sm mb-2">
+          {t('notificationTester.instructions.title')}
+        </h5>
         <ul className="text-xs text-muted-foreground space-y-1">
-          <li>• Cliquez sur le bouton <Send className="w-3 h-3 inline" /> pour envoyer une notification test</li>
-          <li>• Les notifications apparaîtront dans la cloche de notifications en haut à droite</li>
-          <li>• Un toast de confirmation s'affichera également</li>
-          <li>• Vous pouvez tester les différentes catégories et types d'événements</li>
-          <li>• Les notifications sont persistantes et resteront visibles même après rafraîchissement</li>
+          <li>
+            • {t('notificationTester.instructions.items.sendButton.part1')} <Send className="w-3 h-3 inline" /> {t('notificationTester.instructions.items.sendButton.part2')}
+          </li>
+          <li>
+            • {t('notificationTester.instructions.items.bellAppearance')}
+          </li>
+          <li>
+            • {t('notificationTester.instructions.items.toastConfirmation')}
+          </li>
+          <li>
+            • {t('notificationTester.instructions.items.testCategories')}
+          </li>
+          <li>
+            • {t('notificationTester.instructions.items.persistence')}
+          </li>
         </ul>
       </div>
     </div>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,21 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import en from './locales/en.json';
+import fr from './locales/fr.json';
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      fr: { translation: fr }
+    },
+    lng: 'fr',
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false
+    }
+  });
+
+export default i18n;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,132 @@
+{
+  "notificationTester": {
+    "noUser": {
+      "title": "Notification Tester",
+      "message": "You must be logged in to test notifications."
+    },
+    "toast": {
+      "success": "Notification \"{{eventName}}\" sent successfully!",
+      "error": "Error sending notification"
+    },
+    "header": {
+      "title": "MTG Artisan Notification Tester",
+      "description": "Test the different types of notifications in the app. Notifications will appear in the bell at the top right and as a toast."
+    },
+    "sendButton": {
+      "title": "Send this notification"
+    },
+    "categories": {
+      "orders": "Orders",
+      "services": "Services",
+      "messages": "Messages",
+      "reviews": "Reviews",
+      "shop": "Shop",
+      "system": "System"
+    },
+    "events": {
+      "orderPaid": {
+        "label": "Order paid",
+        "description": "Simulate a successfully paid order"
+      },
+      "orderShipped": {
+        "label": "Order shipped",
+        "description": "Simulate an order being shipped"
+      },
+      "alterCommissioned": {
+        "label": "Alter commissioned",
+        "description": "Simulate ordering a MTG alter"
+      },
+      "tokenReady": {
+        "label": "Tokens ready",
+        "description": "Simulate custom tokens ready"
+      },
+      "coachingScheduled": {
+        "label": "Coaching scheduled",
+        "description": "Simulate a scheduled coaching session"
+      },
+      "deckbuildingCompleted": {
+        "label": "Deck completed",
+        "description": "Simulate a finished deck build"
+      },
+      "messageNew": {
+        "label": "New message",
+        "description": "Simulate a new message received"
+      },
+      "messageCommissionRequest": {
+        "label": "Commission request",
+        "description": "Simulate a custom commission request"
+      },
+      "reviewPosted": {
+        "label": "New review",
+        "description": "Simulate a new customer review"
+      },
+      "shopVerified": {
+        "label": "Shop verified",
+        "description": "Simulate a shop verification"
+      },
+      "productLowStock": {
+        "label": "Low stock",
+        "description": "Simulate a low stock alert"
+      },
+      "payoutCompleted": {
+        "label": "Payout received",
+        "description": "Simulate a received payout"
+      },
+      "systemUpdate": {
+        "label": "System update",
+        "description": "Simulate a system update notification"
+      },
+      "accountLoginNewDevice": {
+        "label": "New login",
+        "description": "Simulate a login from a new device"
+      }
+    },
+    "instructions": {
+      "title": "💡 Instructions",
+      "items": {
+        "sendButton": {
+          "part1": "Click the button",
+          "part2": "to send a test notification"
+        },
+        "bellAppearance": "Notifications will appear in the notification bell at the top right",
+        "toastConfirmation": "A confirmation toast will also appear",
+        "testCategories": "You can test the different categories and event types",
+        "persistence": "Notifications are persistent and remain visible even after refresh"
+      }
+    }
+  },
+  "notificationTest": {
+    "title": "Notification Test",
+    "description": "Development page to test the MTG Artisan notification system.",
+    "architectureTitle": "System Architecture",
+    "dbTablesTitle": "📊 Database Tables",
+    "dbTables": {
+      "events": "Incoming events queue",
+      "notifications": "Notifications created for users",
+      "preferences": "User preferences",
+      "deliveries": "Delivery tasks (email, push, etc.)",
+      "templates": "Message templates"
+    },
+    "functionsTitle": "⚙️ Supabase Functions",
+    "functions": {
+      "eventsEmit": "Emits an event",
+      "eventsFanout": "Processes events into notifications",
+      "notificationsRead": "Marks as read",
+      "notificationsSeen": "Marks as seen",
+      "preferences": "Manages preferences"
+    },
+    "flowTitle": "🔄 Data Flow",
+    "flow": {
+      "step1": "1. The application emits an event via",
+      "step2": "2. The event is stored in",
+      "step3": {
+        "part1": "3. The",
+        "part2": "function processes the events"
+      },
+      "step4": "4. Notifications are created in",
+      "step5": "5. Delivery tasks are created in",
+      "step6": "6. The React interface subscribes to realtime changes",
+      "step7": "7. Notifications appear in the bell and as toasts"
+    }
+  }
+}

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,0 +1,132 @@
+{
+  "notificationTester": {
+    "noUser": {
+      "title": "Testeur de Notifications",
+      "message": "Vous devez être connecté pour tester les notifications."
+    },
+    "toast": {
+      "success": "Notification \"{{eventName}}\" envoyée avec succès !",
+      "error": "Erreur lors de l'envoi de la notification"
+    },
+    "header": {
+      "title": "Testeur de Notifications MTG Artisan",
+      "description": "Testez les différents types de notifications de l'application. Les notifications apparaîtront dans la cloche en haut à droite et comme toast."
+    },
+    "sendButton": {
+      "title": "Envoyer cette notification"
+    },
+    "categories": {
+      "orders": "Commandes",
+      "services": "Services",
+      "messages": "Messages",
+      "reviews": "Avis",
+      "shop": "Boutique",
+      "system": "Système"
+    },
+    "events": {
+      "orderPaid": {
+        "label": "Commande payée",
+        "description": "Simuler une commande payée avec succès"
+      },
+      "orderShipped": {
+        "label": "Commande expédiée",
+        "description": "Simuler l'expédition d'une commande"
+      },
+      "alterCommissioned": {
+        "label": "Alter commandé",
+        "description": "Simuler la commande d'un alter MTG"
+      },
+      "tokenReady": {
+        "label": "Tokens prêts",
+        "description": "Simuler des tokens personnalisés prêts"
+      },
+      "coachingScheduled": {
+        "label": "Coaching programmé",
+        "description": "Simuler une session de coaching programmée"
+      },
+      "deckbuildingCompleted": {
+        "label": "Deck terminé",
+        "description": "Simuler un deck construit terminé"
+      },
+      "messageNew": {
+        "label": "Nouveau message",
+        "description": "Simuler un nouveau message reçu"
+      },
+      "messageCommissionRequest": {
+        "label": "Demande de commission",
+        "description": "Simuler une demande de commission personnalisée"
+      },
+      "reviewPosted": {
+        "label": "Nouvel avis",
+        "description": "Simuler un nouvel avis client"
+      },
+      "shopVerified": {
+        "label": "Boutique vérifiée",
+        "description": "Simuler la vérification d'une boutique"
+      },
+      "productLowStock": {
+        "label": "Stock faible",
+        "description": "Simuler une alerte de stock faible"
+      },
+      "payoutCompleted": {
+        "label": "Paiement reçu",
+        "description": "Simuler un paiement reçu"
+      },
+      "systemUpdate": {
+        "label": "Mise à jour système",
+        "description": "Simuler une notification de mise à jour"
+      },
+      "accountLoginNewDevice": {
+        "label": "Nouvelle connexion",
+        "description": "Simuler une connexion depuis un nouvel appareil"
+      }
+    },
+    "instructions": {
+      "title": "💡 Instructions",
+      "items": {
+        "sendButton": {
+          "part1": "Cliquez sur le bouton",
+          "part2": "pour envoyer une notification test"
+        },
+        "bellAppearance": "Les notifications apparaîtront dans la cloche de notifications en haut à droite",
+        "toastConfirmation": "Un toast de confirmation s'affichera également",
+        "testCategories": "Vous pouvez tester les différentes catégories et types d'événements",
+        "persistence": "Les notifications sont persistantes et resteront visibles même après rafraîchissement"
+      }
+    }
+  },
+  "notificationTest": {
+    "title": "Test des Notifications",
+    "description": "Page de développement pour tester le système de notifications de MTG Artisan.",
+    "architectureTitle": "Architecture du Système",
+    "dbTablesTitle": "📊 Tables de Base de Données",
+    "dbTables": {
+      "events": "Queue d'événements entrants",
+      "notifications": "Notifications créées pour les utilisateurs",
+      "preferences": "Préférences utilisateur",
+      "deliveries": "Tâches de livraison (email, push, etc.)",
+      "templates": "Templates de messages"
+    },
+    "functionsTitle": "⚙️ Fonctions Supabase",
+    "functions": {
+      "eventsEmit": "Émet un événement",
+      "eventsFanout": "Traite les événements en notifications",
+      "notificationsRead": "Marque comme lu",
+      "notificationsSeen": "Marque comme vu",
+      "preferences": "Gère les préférences"
+    },
+    "flowTitle": "🔄 Flux de Données",
+    "flow": {
+      "step1": "1. L'application émet un événement via",
+      "step2": "2. L'événement est stocké dans",
+      "step3": {
+        "part1": "3. La fonction",
+        "part2": "traite les événements"
+      },
+      "step4": "4. Les notifications sont créées dans",
+      "step5": "5. Les tâches de livraison sont créées dans",
+      "step6": "6. L'interface React s'abonne aux changements en temps réel",
+      "step7": "7. Les notifications apparaissent dans la cloche et comme toasts"
+    }
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import './i18n';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/NotificationTest.tsx
+++ b/src/pages/NotificationTest.tsx
@@ -1,16 +1,17 @@
 import React from "react";
 import { NotificationTester } from "../components/Notifications/NotificationTester";
+import { useTranslation } from "react-i18next";
 
 export function NotificationTest() {
+  const { t } = useTranslation();
   return (
     <div className="max-w-6xl mx-auto p-6">
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-foreground mb-2">
-          Test des Notifications
+          {t('notificationTest.title')}
         </h1>
         <p className="text-muted-foreground">
-          Page de développement pour tester le système de notifications de MTG
-          Artisan.
+          {t('notificationTest.description')}
         </p>
       </div>
 
@@ -18,56 +19,52 @@ export function NotificationTest() {
 
       <div className="mt-8 p-6 bg-card border border-border rounded-lg">
         <h2 className="text-xl font-semibold text-foreground mb-4">
-          Architecture du Système
+          {t('notificationTest.architectureTitle')}
         </h2>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
             <h3 className="font-medium text-foreground mb-3">
-              📊 Tables de Base de Données
+              {t('notificationTest.dbTablesTitle')}
             </h3>
             <ul className="text-sm text-muted-foreground space-y-1">
               <li>
-                • <code>notification_events</code> - Queue d'événements entrants
+                • <code>notification_events</code> - {t('notificationTest.dbTables.events')}
               </li>
               <li>
-                • <code>notifications</code> - Notifications créées pour les
-                utilisateurs
+                • <code>notifications</code> - {t('notificationTest.dbTables.notifications')}
               </li>
               <li>
-                • <code>notification_preferences</code> - Préférences
-                utilisateur
+                • <code>notification_preferences</code> - {t('notificationTest.dbTables.preferences')}
               </li>
               <li>
-                • <code>notification_deliveries</code> - Tâches de livraison
-                (email, push, etc.)
+                • <code>notification_deliveries</code> - {t('notificationTest.dbTables.deliveries')}
               </li>
               <li>
-                • <code>notification_templates</code> - Templates de messages
+                • <code>notification_templates</code> - {t('notificationTest.dbTables.templates')}
               </li>
             </ul>
           </div>
 
           <div>
             <h3 className="font-medium text-foreground mb-3">
-              ⚙️ Fonctions Supabase
+              {t('notificationTest.functionsTitle')}
             </h3>
             <ul className="text-sm text-muted-foreground space-y-1">
               <li>
-                • <code>events-emit</code> - Émet un événement
+                • <code>events-emit</code> - {t('notificationTest.functions.eventsEmit')}
               </li>
               <li>
-                • <code>events-fanout</code> - Traite les événements en
-                notifications
+                • <code>events-fanout</code> - {t('notificationTest.functions.eventsFanout')}
               </li>
               <li>
-                • <code>notifications-read</code> - Marque comme lu
+                • <code>notifications-read</code> - {t('notificationTest.functions.notificationsRead')}
               </li>
               <li>
-                • <code>notifications-seen</code> - Marque comme vu
+                • <code>notifications-seen</code> - {t('notificationTest.functions.notificationsSeen')}
               </li>
               <li>
-                • <code>preferences</code> - Gère les préférences
+                • <code>preferences</code> - {t('notificationTest.functions.preferences')}
               </li>
             </ul>
           </div>
@@ -75,30 +72,30 @@ export function NotificationTest() {
 
         <div className="mt-6 p-4 bg-muted/30 border border-border rounded-lg">
           <h4 className="font-medium text-foreground text-sm mb-2">
-            🔄 Flux de Données
+            {t('notificationTest.flowTitle')}
           </h4>
           <ol className="text-xs text-muted-foreground space-y-1">
             <li>
-              1. L'application émet un événement via{" "}
+              {t('notificationTest.flow.step1')} {" "}
               <code>NotificationService.emitEvent()</code>
             </li>
             <li>
-              2. L'événement est stocké dans <code>notification_events</code>
+              {t('notificationTest.flow.step2')} <code>notification_events</code>
             </li>
             <li>
-              3. La fonction <code>events-fanout</code> traite les événements
+              {t('notificationTest.flow.step3.part1')} {" "}
+              <code>events-fanout</code> {" "}
+              {t('notificationTest.flow.step3.part2')}
             </li>
             <li>
-              4. Les notifications sont créées dans <code>notifications</code>
+              {t('notificationTest.flow.step4')} <code>notifications</code>
             </li>
             <li>
-              5. Les tâches de livraison sont créées dans{" "}
+              {t('notificationTest.flow.step5')} {" "}
               <code>notification_deliveries</code>
             </li>
-            <li>6. L'interface React s'abonne aux changements en temps réel</li>
-            <li>
-              7. Les notifications apparaissent dans la cloche et comme toasts
-            </li>
+            <li>{t('notificationTest.flow.step6')}</li>
+            <li>{t('notificationTest.flow.step7')}</li>
           </ol>
         </div>
       </div>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,6 +11,7 @@
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
+    "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx",
 


### PR DESCRIPTION
## Summary
- add i18n setup and translation files for English and French
- translate notification tester UI and sample page
- enable JSON imports in TypeScript config

## Testing
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba6c52e11c832687d54d9f5a4d3724