### PR TITLE
feat: localize create service toasts

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,0 +1,7 @@
+{
+  "createService": {
+    "needShop": "Please create your shop first",
+    "success": "Service created successfully!",
+    "error": "Failed to create service"
+  }
+}

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1,0 +1,7 @@
+{
+  "createService": {
+    "needShop": "Veuillez d'abord créer votre boutique",
+    "success": "Service créé avec succès !",
+    "error": "Échec de la création du service"
+  }
+}

--- a/src/pages/Creator/CreateService.tsx
+++ b/src/pages/Creator/CreateService.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "../../contexts/AuthContext";
 import supabase from "../../lib/supabase";
 import { Save, X } from "lucide-react";
 import toast from "react-hot-toast";
+import { t } from "i18next";
 
 export function CreateService() {
   const { user } = useAuth();
@@ -41,7 +42,7 @@ export function CreateService() {
       setCategories(categoriesResult.data || []);
 
       if (!shopResult.data) {
-        toast.error("Please create your shop first");
+        toast.error(t("createService.needShop"));
         navigate("/creator/shop");
         return;
       }
@@ -71,11 +72,11 @@ export function CreateService() {
 
       if (error) throw error;
 
-      toast.success("Service created successfully!");
+      toast.success(t("createService.success"));
       navigate("/dashboard/creator");
     } catch (error: any) {
       console.error("Error creating service:", error);
-      toast.error(error.message || "Failed to create service");
+      toast.error(error.message || t("createService.error"));
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
## Summary
- localize toast messages in the create service page
- add English and French translations for create service messages

## Testing
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba6c57988883268c139d32c5fa9410