### PR TITLE
Add i18n support for debug notification toasts

### DIFF
--- a/src/components/Debug/DirectNotificationTest.tsx
+++ b/src/components/Debug/DirectNotificationTest.tsx
@@ -2,9 +2,11 @@ import React from "react";
 import { useAuth } from "../../contexts/AuthContext";
 import supabase from "../../lib/supabase";
 import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
 
 export function DirectNotificationTest() {
   const { user } = useAuth();
+  const { t } = useTranslation();
 
   if (!user) return null;
 
@@ -30,9 +32,9 @@ export function DirectNotificationTest() {
       );
 
       if (error) throw error;
-      toast.success("Notification créée directement !");
+      toast.success(t("debug.directNotificationTest.createSuccess"));
     } catch (error) {
-      toast.error("Erreur lors de la création");
+      toast.error(t("debug.directNotificationTest.createError"));
       console.error(error);
     }
   };

--- a/src/components/Debug/QuickNotificationTest.tsx
+++ b/src/components/Debug/QuickNotificationTest.tsx
@@ -3,10 +3,12 @@ import { useQueryClient } from "@tanstack/react-query";
 import { NotificationService } from "../../services/notificationService";
 import { useAuth } from "../../contexts/AuthContext";
 import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
 
 export function QuickNotificationTest() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
+  const { t } = useTranslation();
 
   if (!user) return null;
 
@@ -46,7 +48,10 @@ export function QuickNotificationTest() {
     try {
       await NotificationService.emitEvent(eventName, targetUserIds, payload);
       toast.success(
-        `Notification "${eventName}" envoyée à ${targetUserIds.length} utilisateur(s) !`
+        t("debug.quickNotificationTest.sendSuccess", {
+          eventName,
+          count: targetUserIds.length,
+        })
       );
 
       // Forcer la mise à jour des données après un délai
@@ -61,7 +66,7 @@ export function QuickNotificationTest() {
         });
       }, 1000);
     } catch (error) {
-      toast.error("Erreur lors de l'envoi");
+      toast.error(t("debug.quickNotificationTest.sendError"));
       console.error(error);
     }
   };
@@ -89,9 +94,9 @@ export function QuickNotificationTest() {
         "../../services/notificationService"
       );
       await NotificationService.markAllAsRead();
-      toast.success("Test 'Tout lire' terminé ! Vérifiez la console.");
+      toast.success(t("debug.quickNotificationTest.markAllSuccess"));
     } catch (error) {
-      toast.error("Erreur lors du test 'Tout lire'");
+      toast.error(t("debug.quickNotificationTest.markAllError"));
       console.error(error);
     }
   };

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,49 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+const resources = {
+  en: {
+    translation: {
+      debug: {
+        quickNotificationTest: {
+          sendSuccess: 'Notification "{{eventName}}" sent to {{count}} user(s)!',
+          sendError: 'Error while sending',
+          markAllSuccess: "'Mark all as read' test completed! Check console.",
+          markAllError: "Error during 'Mark all as read' test",
+        },
+        directNotificationTest: {
+          createSuccess: 'Notification created directly!',
+          createError: 'Error while creating',
+        },
+      },
+    },
+  },
+  fr: {
+    translation: {
+      debug: {
+        quickNotificationTest: {
+          sendSuccess:
+            'Notification "{{eventName}}" envoyée à {{count}} utilisateur(s) !',
+          sendError: "Erreur lors de l'envoi",
+          markAllSuccess: "Test 'Tout lire' terminé ! Vérifiez la console.",
+          markAllError: "Erreur lors du test 'Tout lire'",
+        },
+        directNotificationTest: {
+          createSuccess: 'Notification créée directement !',
+          createError: 'Erreur lors de la création',
+        },
+      },
+    },
+  },
+};
+
+i18n.use(initReactI18next).init({
+  resources,
+  lng: 'fr',
+  fallbackLng: 'en',
+  interpolation: {
+    escapeValue: false,
+  },
+});
+
+export default i18n;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import './i18n';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- add i18next initialization with English and French resources for debug notification toasts
- use `t()` translations for success and error toasts in debug notification components
- initialize i18n in the application entry point

## Testing
- `npm test`
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_68ba6c6198848326943f4e4c35321780