### PR TITLE
feat: localize admin dashboard

### DIFF
--- a/public/locales/en/adminDashboard.json
+++ b/public/locales/en/adminDashboard.json
@@ -1,0 +1,33 @@
+{
+  "title": "Admin Panel",
+  "subtitle": "Manage ManaShop stores",
+  "stats": {
+    "totalUsers": "Total Users",
+    "totalCreators": "Creators",
+    "productsServices": "Products & Services",
+    "totalRevenue": "Total Revenue"
+  },
+  "recentOrders": {
+    "title": "Recent Orders",
+    "viewAll": "View All",
+    "none": "No recent orders",
+    "orderNumber": "Order #{{id}}",
+    "itemCount": "{{count}} item",
+    "itemCount_plural": "{{count}} items"
+  },
+  "quickActions": {
+    "title": "Quick Actions",
+    "manageUsers": {
+      "title": "Manage Users",
+      "description": "View and edit user profiles"
+    },
+    "moderateContent": {
+      "title": "Moderate Content",
+      "description": "Review and approve products"
+    },
+    "reports": {
+      "title": "Reports",
+      "description": "Analyze performance"
+    }
+  }
+}

--- a/public/locales/fr/adminDashboard.json
+++ b/public/locales/fr/adminDashboard.json
@@ -1,0 +1,33 @@
+{
+  "title": "Admin Panel",
+  "subtitle": "Gestion des boutiques ManaShop",
+  "stats": {
+    "totalUsers": "Utilisateurs totaux",
+    "totalCreators": "Créateurs",
+    "productsServices": "Produits & Services",
+    "totalRevenue": "Revenus totaux"
+  },
+  "recentOrders": {
+    "title": "Commandes Récentes",
+    "viewAll": "Voir toutes",
+    "none": "Aucune commande récente",
+    "orderNumber": "Commande #{{id}}",
+    "itemCount": "{{count}} article",
+    "itemCount_plural": "{{count}} articles"
+  },
+  "quickActions": {
+    "title": "Actions Rapides",
+    "manageUsers": {
+      "title": "Gérer les Utilisateurs",
+      "description": "Voir et modifier les profils utilisateurs"
+    },
+    "moderateContent": {
+      "title": "Modérer le Contenu",
+      "description": "Examiner et approuver les produits"
+    },
+    "reports": {
+      "title": "Rapports",
+      "description": "Analyser les performances"
+    }
+  }
+}

--- a/src/pages/Admin/AdminDashboard.tsx
+++ b/src/pages/Admin/AdminDashboard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import supabase from "../../lib/supabase";
 import {
   Users,
@@ -6,14 +7,14 @@ import {
   Briefcase,
   DollarSign,
   TrendingUp,
-  AlertCircle,
   Shield,
 } from "lucide-react";
 import { LoadingSpinner } from "../../components/UI/LoadingSpinner";
-import { Card, CardHeader, CardContent } from "../../components/UI/Card";
+import { Card } from "../../components/UI/Card";
 import { Button } from "../../components/UI/Button";
 
 export function AdminDashboard() {
+  const { t } = useTranslation();
   const [stats, setStats] = useState({
     totalUsers: 0,
     totalCreators: 0,
@@ -85,10 +86,10 @@ export function AdminDashboard() {
           </div>
           <div>
             <h1 className="text-4xl md:text-5xl font-light text-foreground tracking-tight">
-              Admin Panel
+              {t("adminDashboard.title")}
             </h1>
             <p className="text-muted-foreground/70 text-lg">
-              Gestion des boutiques ManaShop
+              {t("adminDashboard.subtitle")}
             </p>
           </div>
         </div>
@@ -104,7 +105,7 @@ export function AdminDashboard() {
             {stats.totalUsers.toLocaleString()}
           </div>
           <div className="text-muted-foreground/70 text-sm">
-            Utilisateurs totaux
+            {t("adminDashboard.stats.totalUsers")}
           </div>
         </Card>
 
@@ -115,7 +116,9 @@ export function AdminDashboard() {
           <div className="text-3xl font-light text-foreground mb-2">
             {stats.totalCreators.toLocaleString()}
           </div>
-          <div className="text-muted-foreground/70 text-sm">Créateurs</div>
+          <div className="text-muted-foreground/70 text-sm">
+            {t("adminDashboard.stats.totalCreators")}
+          </div>
         </Card>
 
         <Card className="text-center p-6">
@@ -126,7 +129,7 @@ export function AdminDashboard() {
             {(stats.totalProducts + stats.totalServices).toLocaleString()}
           </div>
           <div className="text-muted-foreground/70 text-sm">
-            Produits & Services
+            {t("adminDashboard.stats.productsServices")}
           </div>
         </Card>
 
@@ -137,7 +140,9 @@ export function AdminDashboard() {
           <div className="text-3xl font-light text-foreground mb-2">
             ${stats.totalRevenue.toLocaleString()}
           </div>
-          <div className="text-muted-foreground/70 text-sm">Revenus totaux</div>
+          <div className="text-muted-foreground/70 text-sm">
+            {t("adminDashboard.stats.totalRevenue")}
+          </div>
         </Card>
       </div>
 
@@ -145,10 +150,10 @@ export function AdminDashboard() {
       <div className="mb-12">
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-2xl font-light text-foreground tracking-tight">
-            Commandes Récentes
+            {t("adminDashboard.recentOrders.title")}
           </h2>
           <Button variant="outline" size="sm">
-            Voir toutes
+            {t("adminDashboard.recentOrders.viewAll")}
           </Button>
         </div>
 
@@ -157,7 +162,7 @@ export function AdminDashboard() {
             <Card className="text-center p-12">
               <Package className="h-16 w-16 text-muted-foreground/40 mx-auto mb-4" />
               <p className="text-muted-foreground/70">
-                Aucune commande récente
+                {t("adminDashboard.recentOrders.none")}
               </p>
             </Card>
           ) : (
@@ -166,7 +171,7 @@ export function AdminDashboard() {
                 <div className="flex items-center justify-between">
                   <div>
                     <h3 className="text-lg font-light text-foreground">
-                      Commande #{order.id.slice(-8)}
+                      {t("adminDashboard.recentOrders.orderNumber", { id: order.id.slice(-8) })}
                     </h3>
                     <p className="text-muted-foreground/70 text-sm">
                       {new Date(order.created_at).toLocaleDateString("fr-FR", {
@@ -178,8 +183,9 @@ export function AdminDashboard() {
                       })}
                     </p>
                     <p className="text-muted-foreground/70 text-sm">
-                      {order.order_items?.length || 0} article
-                      {order.order_items?.length > 1 ? "s" : ""}
+                      {t("adminDashboard.recentOrders.itemCount", {
+                        count: order.order_items?.length || 0,
+                      })}
                     </p>
                   </div>
                   <div className="text-right">
@@ -200,7 +206,7 @@ export function AdminDashboard() {
       {/* Quick Actions */}
       <div>
         <h2 className="text-2xl font-light text-foreground tracking-tight mb-6">
-          Actions Rapides
+          {t("adminDashboard.quickActions.title")}
         </h2>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -209,10 +215,10 @@ export function AdminDashboard() {
               <Users className="h-8 w-8 text-primary" />
             </div>
             <h3 className="text-lg font-light text-foreground mb-2">
-              Gérer les Utilisateurs
+              {t("adminDashboard.quickActions.manageUsers.title")}
             </h3>
             <p className="text-muted-foreground/70 text-sm">
-              Voir et modifier les profils utilisateurs
+              {t("adminDashboard.quickActions.manageUsers.description")}
             </p>
           </Card>
 
@@ -221,10 +227,10 @@ export function AdminDashboard() {
               <Package className="h-8 w-8 text-primary" />
             </div>
             <h3 className="text-lg font-light text-foreground mb-2">
-              Modérer le Contenu
+              {t("adminDashboard.quickActions.moderateContent.title")}
             </h3>
             <p className="text-muted-foreground/70 text-sm">
-              Examiner et approuver les produits
+              {t("adminDashboard.quickActions.moderateContent.description")}
             </p>
           </Card>
 
@@ -233,10 +239,10 @@ export function AdminDashboard() {
               <TrendingUp className="h-8 w-8 text-primary" />
             </div>
             <h3 className="text-lg font-light text-foreground mb-2">
-              Rapports
+              {t("adminDashboard.quickActions.reports.title")}
             </h3>
             <p className="text-muted-foreground/70 text-sm">
-              Analyser les performances
+              {t("adminDashboard.quickActions.reports.description")}
             </p>
           </Card>
         </div>


### PR DESCRIPTION
## Summary
- localize AdminDashboard strings and use i18next
- add English and French translations for admin dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba6c6341a48326bc587a80cbdc7387