### PR TITLE
feat: add translations for artist carousel

### DIFF
--- a/src/components/UI/ArtistCarousel.tsx
+++ b/src/components/UI/ArtistCarousel.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   ChevronLeft,
   ChevronRight,
@@ -12,6 +13,7 @@ import { usePopularArtists } from "../../hooks/usePopularArtists";
 import { LoadingSpinner } from "./LoadingSpinner";
 
 export function ArtistCarousel() {
+  const { t } = useTranslation();
   const { artists, loading, error } = usePopularArtists(8);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
@@ -56,12 +58,14 @@ export function ArtistCarousel() {
           <Users className="h-12 w-12 text-muted-foreground" />
         </div>
         <h3 className="text-xl font-light text-foreground mb-3">
-          {error ? "Erreur de chargement" : "Aucun artiste disponible"}
+          {error
+            ? t("artistCarousel.error")
+            : t("artistCarousel.noArtists")}
         </h3>
         <p className="text-muted-foreground/70 max-w-md mx-auto">
           {error
-            ? "Impossible de charger les artistes populaires pour le moment."
-            : "Les artistes populaires apparaîtront ici une fois qu'ils auront rejoint la plateforme."}
+            ? t("artistCarousel.errorDescription")
+            : t("artistCarousel.noArtistsDescription")}
         </p>
 
         {/* Fallback avec des cartes d'exemple */}
@@ -71,10 +75,10 @@ export function ArtistCarousel() {
               <Star className="w-10 h-10 text-primary" />
             </div>
             <h4 className="text-lg font-light text-foreground mb-2">
-              Artistes Vérifiés
+              {t("artistCarousel.verifiedArtistsTitle")}
             </h4>
             <p className="text-muted-foreground/70 text-sm">
-              Tous nos artistes sont des professionnels qualifiés
+              {t("artistCarousel.verifiedArtistsDescription")}
             </p>
           </div>
 
@@ -83,10 +87,10 @@ export function ArtistCarousel() {
               <Package className="w-10 h-10 text-primary" />
             </div>
             <h4 className="text-lg font-light text-foreground mb-2">
-              Créations Uniques
+              {t("artistCarousel.uniqueCreationsTitle")}
             </h4>
             <p className="text-muted-foreground/70 text-sm">
-              Des œuvres d'art personnalisées et originales
+              {t("artistCarousel.uniqueCreationsDescription")}
             </p>
           </div>
 
@@ -95,10 +99,10 @@ export function ArtistCarousel() {
               <Briefcase className="w-10 h-10 text-primary" />
             </div>
             <h4 className="text-lg font-light text-foreground mb-2">
-              Services Premium
+              {t("artistCarousel.premiumServicesTitle")}
             </h4>
             <p className="text-muted-foreground/70 text-sm">
-              Expertise et qualité garanties
+              {t("artistCarousel.premiumServicesDescription")}
             </p>
           </div>
         </div>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,18 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import fr from "./locales/fr/translation.json";
+import en from "./locales/en/translation.json";
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      fr: { translation: fr },
+      en: { translation: en },
+    },
+    lng: "fr",
+    fallbackLng: "fr",
+    interpolation: { escapeValue: false },
+  });
+
+export default i18n;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,0 +1,14 @@
+{
+  "artistCarousel": {
+    "error": "Loading error",
+    "noArtists": "No artists available",
+    "errorDescription": "Unable to load popular artists at the moment.",
+    "noArtistsDescription": "Popular artists will appear here once they join the platform.",
+    "verifiedArtistsTitle": "Verified Artists",
+    "verifiedArtistsDescription": "All our artists are qualified professionals",
+    "uniqueCreationsTitle": "Unique Creations",
+    "uniqueCreationsDescription": "Custom and original artworks",
+    "premiumServicesTitle": "Premium Services",
+    "premiumServicesDescription": "Expertise and quality guaranteed"
+  }
+}

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1,0 +1,14 @@
+{
+  "artistCarousel": {
+    "error": "Erreur de chargement",
+    "noArtists": "Aucun artiste disponible",
+    "errorDescription": "Impossible de charger les artistes populaires pour le moment.",
+    "noArtistsDescription": "Les artistes populaires apparaîtront ici une fois qu'ils auront rejoint la plateforme.",
+    "verifiedArtistsTitle": "Artistes Vérifiés",
+    "verifiedArtistsDescription": "Tous nos artistes sont des professionnels qualifiés",
+    "uniqueCreationsTitle": "Créations Uniques",
+    "uniqueCreationsDescription": "Des œuvres d'art personnalisées et originales",
+    "premiumServicesTitle": "Services Premium",
+    "premiumServicesDescription": "Expertise et qualité garanties"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import './i18n';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+declare module "*.json";


### PR DESCRIPTION
## Summary
- add translation resources for artist carousel
- integrate i18next and translation hook
- replace hard-coded strings with `t('artistCarousel...')`

## Testing
- `npm test`
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*


------
https://chatgpt.com/codex/tasks/task_e_68ba6c69a75083269c2d6e35929180bc