### PR TITLE
chore: translate notification messages to English

### DIFF
--- a/src/components/Debug/DirectNotificationTest.tsx
+++ b/src/components/Debug/DirectNotificationTest.tsx
@@ -14,7 +14,7 @@ export function DirectNotificationTest() {
     category: string
   ) => {
     try {
-      // Utiliser la fonction notifications-direct pour bypasser RLS
+      // Use notifications-direct function to bypass RLS
       const { error } = await supabase.functions.invoke(
         "notifications-direct",
         {
@@ -30,37 +30,37 @@ export function DirectNotificationTest() {
       );
 
       if (error) throw error;
-      toast.success("Notification créée directement !");
+      toast.success("Notification created directly!");
     } catch (error) {
-      toast.error("Erreur lors de la création");
+      toast.error("Error creating notification");
       console.error(error);
     }
   };
 
   const testNotifications = [
     {
-      title: "💳 Commande payée",
-      body: "Votre commande TEST-123 a été payée (89.99€)",
+      title: "💳 Order paid",
+      body: "Your order TEST-123 has been paid (89.99€)",
       category: "orders",
     },
     {
-      title: "🎨 Alter commandé",
-      body: "Votre alter Lightning Bolt a été commandé",
+      title: "🎨 Alter ordered",
+      body: "Your Lightning Bolt alter has been ordered",
       category: "orders",
     },
     {
-      title: "⚠️ Stock faible",
-      body: "Plus que 2 exemplaires de Test Product",
+      title: "⚠️ Low stock",
+      body: "Only 2 copies of Test Product left",
       category: "shop",
     },
     {
-      title: "💬 Nouveau message",
-      body: "Test User vous a envoyé un message",
+      title: "💬 New message",
+      body: "Test User sent you a message",
       category: "messages",
     },
     {
-      title: "✅ Boutique vérifiée",
-      body: "Votre boutique Ma Boutique Test est maintenant vérifiée",
+      title: "✅ Shop verified",
+      body: "Your shop My Test Shop is now verified",
       category: "shop",
     },
   ];
@@ -68,7 +68,7 @@ export function DirectNotificationTest() {
   return (
     <div className="fixed bottom-20 right-4 bg-card border border-border rounded-lg p-4 shadow-lg z-50">
       <h3 className="text-sm font-medium text-foreground mb-3">
-        🔧 Test Direct (sans Edge Function)
+        🔧 Direct Test (without Edge Function)
       </h3>
       <div className="space-y-2">
         {testNotifications.map((notif, index) => (

--- a/src/components/Debug/QuickNotificationTest.tsx
+++ b/src/components/Debug/QuickNotificationTest.tsx
@@ -13,27 +13,27 @@ export function QuickNotificationTest() {
   const testNotifications = [
     {
       name: "order.paid",
-      label: "💳 Commande payée",
+      label: "💳 Order paid",
       payload: { orderId: "TEST-123", total: 89.99, currency: "EUR" },
     },
     {
       name: "alter.commissioned",
-      label: "🎨 Alter commandé",
+      label: "🎨 Alter ordered",
       payload: { cardName: "Lightning Bolt", artistName: "Test Artist" },
     },
     {
       name: "product.low_stock",
-      label: "⚠️ Stock faible",
+      label: "⚠️ Low stock",
       payload: { productName: "Test Product", stock: 2 },
     },
     {
       name: "shop.verified",
-      label: "✅ Boutique vérifiée",
-      payload: { shopName: "Ma Boutique Test" },
+      label: "✅ Shop verified",
+      payload: { shopName: "My Test Shop" },
     },
     {
       name: "message.new",
-      label: "💬 Nouveau message",
+      label: "💬 New message",
       payload: { senderName: "Test User" },
     },
   ];
@@ -46,10 +46,10 @@ export function QuickNotificationTest() {
     try {
       await NotificationService.emitEvent(eventName, targetUserIds, payload);
       toast.success(
-        `Notification "${eventName}" envoyée à ${targetUserIds.length} utilisateur(s) !`
+        `Notification "${eventName}" sent to ${targetUserIds.length} user(s)!`
       );
 
-      // Forcer la mise à jour des données après un délai
+      // Force data refresh after a delay
       setTimeout(() => {
         queryClient.invalidateQueries({ queryKey: ["notifications"] });
         queryClient.invalidateQueries({
@@ -61,15 +61,15 @@ export function QuickNotificationTest() {
         });
       }, 1000);
     } catch (error) {
-      toast.error("Erreur lors de l'envoi");
+      toast.error("Error sending");
       console.error(error);
     }
   };
 
   const sendCrossUserNotification = async () => {
-    // Récupérer quelques utilisateurs pour le test cross-user
+    // Fetch some users for the cross-user test
     const prompt = window.prompt(
-      "Entrez l'ID d'un autre utilisateur (ou laissez vide pour vous-même):"
+      "Enter another user's ID (or leave blank for yourself):"
     );
     const targetId = prompt?.trim() || user.id;
 
@@ -77,7 +77,7 @@ export function QuickNotificationTest() {
       "message.new",
       {
         senderName: user.email,
-        message: "Test de notification cross-utilisateur !",
+        message: "Cross-user notification test!",
       },
       [targetId]
     );
@@ -89,9 +89,9 @@ export function QuickNotificationTest() {
         "../../services/notificationService"
       );
       await NotificationService.markAllAsRead();
-      toast.success("Test 'Tout lire' terminé ! Vérifiez la console.");
+      toast.success("'Mark all as read' test complete! Check the console.");
     } catch (error) {
-      toast.error("Erreur lors du test 'Tout lire'");
+      toast.error("Error during 'Mark all as read' test");
       console.error(error);
     }
   };
@@ -116,13 +116,13 @@ export function QuickNotificationTest() {
           onClick={testMarkAllAsRead}
           className="block w-full text-left text-xs bg-orange-500/10 hover:bg-orange-500/20 text-orange-600 px-3 py-2 rounded transition-colors"
         >
-          🔄 Test "Tout lire"
+          🔄 'Mark all as read' test
         </button>
         <button
           onClick={sendCrossUserNotification}
           className="block w-full text-left text-xs bg-purple-500/10 hover:bg-purple-500/20 text-purple-600 px-3 py-2 rounded transition-colors"
         >
-          👥 Test Cross-Utilisateur
+          👥 Cross-user test
         </button>
       </div>
       <p className="text-xs text-muted-foreground mt-2">

--- a/src/components/Notifications/NotificationTester.tsx
+++ b/src/components/Notifications/NotificationTester.tsx
@@ -6,32 +6,32 @@ import toast from 'react-hot-toast';
 
 const TEST_EVENTS = [
   {
-    category: 'Commandes',
+    category: 'Orders',
     icon: Package,
     color: 'text-blue-500',
     events: [
       {
         name: 'order.paid',
-        label: 'Commande payée',
-        description: 'Simuler une commande payée avec succès',
-        payload: { orderId: 'ORD-123', total: 89.99, currency: 'EUR', buyerName: 'Alice Dupont' }
+        label: 'Order paid',
+        description: 'Simulate a successfully paid order',
+        payload: { orderId: 'ORD-123', total: 89.99, currency: 'EUR', buyerName: 'Alice Smith' }
       },
       {
         name: 'order.shipped',
-        label: 'Commande expédiée',
-        description: 'Simuler l\'expédition d\'une commande',
+        label: 'Order shipped',
+        description: 'Simulate a shipped order',
         payload: { orderId: 'ORD-123', trackingNumber: 'FR123456789', shopName: 'ArtMaster Studio' }
       },
       {
         name: 'alter.commissioned',
-        label: 'Alter commandé',
-        description: 'Simuler la commande d\'un alter MTG',
-        payload: { cardName: 'Lightning Bolt', artistName: 'Marie Artisan', orderId: 'ALT-456' }
+        label: 'Alter commissioned',
+        description: 'Simulate an MTG alter order',
+        payload: { cardName: 'Lightning Bolt', artistName: 'Mary Artisan', orderId: 'ALT-456' }
       },
       {
         name: 'token.ready',
-        label: 'Tokens prêts',
-        description: 'Simuler des tokens personnalisés prêts',
+        label: 'Tokens ready',
+        description: 'Simulate custom tokens ready',
         payload: { tokenName: 'Goblin Token Set', orderId: 'TOK-789' }
       }
     ]
@@ -43,14 +43,14 @@ const TEST_EVENTS = [
     events: [
       {
         name: 'coaching.scheduled',
-        label: 'Coaching programmé',
-        description: 'Simuler une session de coaching programmée',
+        label: 'Coaching scheduled',
+        description: 'Simulate a scheduled coaching session',
         payload: { coachName: 'Pro Player', date: '2024-02-15', time: '19:00' }
       },
       {
         name: 'deckbuilding.completed',
-        label: 'Deck terminé',
-        description: 'Simuler un deck construit terminé',
+        label: 'Deck completed',
+        description: 'Simulate a finished deck build',
         payload: { format: 'Modern Burn', builderName: 'DeckMaster', orderId: 'DECK-321' }
       }
     ]
@@ -62,71 +62,71 @@ const TEST_EVENTS = [
     events: [
       {
         name: 'message.new',
-        label: 'Nouveau message',
-        description: 'Simuler un nouveau message reçu',
-        payload: { senderName: 'Bob Collectionneur' }
+        label: 'New message',
+        description: 'Simulate a new message received',
+        payload: { senderName: 'Bob Collector' }
       },
       {
         name: 'message.commission_request',
-        label: 'Demande de commission',
-        description: 'Simuler une demande de commission personnalisée',
+        label: 'Commission request',
+        description: 'Simulate a custom commission request',
         payload: { buyerName: 'Sarah Magic' }
       }
     ]
   },
   {
-    category: 'Avis',
+    category: 'Reviews',
     icon: Star,
     color: 'text-yellow-500',
     events: [
       {
         name: 'review.posted',
-        label: 'Nouvel avis',
-        description: 'Simuler un nouvel avis client',
-        payload: { reviewerName: 'Client Satisfait', rating: 5, productName: 'Alter Lightning Bolt' }
+        label: 'New review',
+        description: 'Simulate a new customer review',
+        payload: { reviewerName: 'Happy Customer', rating: 5, productName: 'Alter Lightning Bolt' }
       }
     ]
   },
   {
-    category: 'Boutique',
+    category: 'Shop',
     icon: Settings,
     color: 'text-orange-500',
     events: [
       {
         name: 'shop.verified',
-        label: 'Boutique vérifiée',
-        description: 'Simuler la vérification d\'une boutique',
-        payload: { shopName: 'Mon Atelier MTG' }
+        label: 'Shop verified',
+        description: 'Simulate a shop verification',
+        payload: { shopName: 'My MTG Workshop' }
       },
       {
         name: 'product.low_stock',
-        label: 'Stock faible',
-        description: 'Simuler une alerte de stock faible',
+        label: 'Low stock',
+        description: 'Simulate a low stock alert',
         payload: { productName: 'Playmat Dragon', stock: 2 }
       },
       {
         name: 'payout.completed',
-        label: 'Paiement reçu',
-        description: 'Simuler un paiement reçu',
+        label: 'Payout received',
+        description: 'Simulate a received payout',
         payload: { amount: 250.50, currency: 'EUR' }
       }
     ]
   },
   {
-    category: 'Système',
+    category: 'System',
     icon: AlertTriangle,
     color: 'text-red-500',
     events: [
       {
         name: 'system.update',
-        label: 'Mise à jour système',
-        description: 'Simuler une notification de mise à jour',
+        label: 'System update',
+        description: 'Simulate a system update notification',
         payload: {}
       },
       {
         name: 'account.login_new_device',
-        label: 'Nouvelle connexion',
-        description: 'Simuler une connexion depuis un nouvel appareil',
+        label: 'New login',
+        description: 'Simulate a login from a new device',
         payload: { device: 'iPhone 15', location: 'Paris, France' }
       }
     ]
@@ -141,10 +141,10 @@ export function NotificationTester() {
     return (
       <div className="p-6 bg-card border border-border rounded-lg">
         <h3 className="text-lg font-semibold text-foreground mb-2">
-          Testeur de Notifications
+          Notification Tester
         </h3>
         <p className="text-muted-foreground">
-          Vous devez être connecté pour tester les notifications.
+          You must be logged in to test notifications.
         </p>
       </div>
     );
@@ -156,10 +156,10 @@ export function NotificationTester() {
     setIsLoading(eventName);
     try {
       await NotificationService.emitEvent(eventName, [user.id], payload);
-      toast.success(`Notification "${eventName}" envoyée avec succès !`);
+      toast.success(`Notification "${eventName}" sent successfully!`);
     } catch (error) {
-      console.error('Erreur lors de l\'envoi de la notification:', error);
-      toast.error('Erreur lors de l\'envoi de la notification');
+      console.error('Error sending notification:', error);
+      toast.error('Error sending notification');
     } finally {
       setIsLoading(null);
     }
@@ -170,11 +170,10 @@ export function NotificationTester() {
       <div className="mb-6">
         <h3 className="text-lg font-semibold text-foreground mb-2 flex items-center space-x-2">
           <Play className="w-5 h-5 text-primary" />
-          <span>Testeur de Notifications MTG Artisan</span>
+          <span>MTG Artisan Notification Tester</span>
         </h3>
         <p className="text-muted-foreground text-sm">
-          Testez les différents types de notifications de l'application. 
-          Les notifications apparaîtront dans la cloche en haut à droite et comme toast.
+          Test the different types of notifications in the app. Notifications will appear in the bell at the top right and as toasts.
         </p>
       </div>
 
@@ -209,7 +208,7 @@ export function NotificationTester() {
                       onClick={() => handleSendNotification(event.name, event.payload)}
                       disabled={isLoading === event.name}
                       className="ml-3 p-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                      title="Envoyer cette notification"
+                      title="Send this notification"
                     >
                       {isLoading === event.name ? (
                         <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
@@ -228,11 +227,11 @@ export function NotificationTester() {
       <div className="mt-6 p-4 bg-muted/30 border border-border rounded-lg">
         <h5 className="font-medium text-foreground text-sm mb-2">💡 Instructions</h5>
         <ul className="text-xs text-muted-foreground space-y-1">
-          <li>• Cliquez sur le bouton <Send className="w-3 h-3 inline" /> pour envoyer une notification test</li>
-          <li>• Les notifications apparaîtront dans la cloche de notifications en haut à droite</li>
-          <li>• Un toast de confirmation s'affichera également</li>
-          <li>• Vous pouvez tester les différentes catégories et types d'événements</li>
-          <li>• Les notifications sont persistantes et resteront visibles même après rafraîchissement</li>
+          <li>• Click the <Send className="w-3 h-3 inline" /> button to send a test notification</li>
+          <li>• Notifications will appear in the notification bell at the top right</li>
+          <li>• A confirmation toast will also appear</li>
+          <li>• You can test the different categories and event types</li>
+          <li>• Notifications are persistent and remain visible even after refresh</li>
         </ul>
       </div>
     </div>

--- a/src/pages/NotificationPreferences.tsx
+++ b/src/pages/NotificationPreferences.tsx
@@ -12,32 +12,32 @@ import toast from "react-hot-toast";
 const categories = [
   {
     key: "orders",
-    label: "Commandes",
-    description: "Nouvelles commandes, mises à jour de statut, livraisons",
+    label: "Orders",
+    description: "New orders, status updates, deliveries",
     icon: "📦",
   },
   {
     key: "messages",
     label: "Messages",
-    description: "Messages de clients et conversations",
+    description: "Customer messages and conversations",
     icon: "💬",
   },
   {
     key: "reviews",
-    label: "Avis",
-    description: "Nouveaux avis et évaluations",
+    label: "Reviews",
+    description: "New reviews and ratings",
     icon: "⭐",
   },
   {
     key: "shop",
-    label: "Boutique",
-    description: "Gestion de boutique, devis, paiements",
+    label: "Shop",
+    description: "Shop management, quotes, payments",
     icon: "🏪",
   },
   {
     key: "system",
-    label: "Système",
-    description: "Mises à jour importantes et maintenance",
+    label: "System",
+    description: "Important updates and maintenance",
     icon: "⚙️",
   },
 ] as const;
@@ -45,14 +45,14 @@ const categories = [
 const channels = [
   {
     key: "inapp",
-    label: "Dans l'app",
-    description: "Notifications dans l'interface",
+    label: "In-app",
+    description: "Notifications inside the interface",
     icon: Bell,
   },
   {
     key: "email",
     label: "Email",
-    description: "Notifications par email",
+    description: "Email notifications",
     icon: Mail,
   },
 ] as const;
@@ -62,13 +62,13 @@ export function NotificationPreferences() {
   const [preferences, setPreferences] = useState<Record<string, boolean>>({});
   const [hasChanges, setHasChanges] = useState(false);
 
-  // Récupérer les préférences actuelles
+  // Fetch current preferences
   const { data: currentPreferences = [], isLoading } = useQuery({
     queryKey: ["notification-preferences"],
     queryFn: NotificationService.getPreferences,
   });
 
-  // Mutation pour sauvegarder les préférences
+  // Mutation to save preferences
   const savePreferencesMutation = useMutation({
     mutationFn: async () => {
       const promises = Object.entries(preferences).map(([key, enabled]) => {
@@ -80,31 +80,31 @@ export function NotificationPreferences() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["notification-preferences"] });
       setHasChanges(false);
-      toast.success("Préférences sauvegardées avec succès");
+      toast.success("Preferences saved successfully");
     },
     onError: (error) => {
-      toast.error("Erreur lors de la sauvegarde des préférences");
+      toast.error("Error saving preferences");
       console.error("Error saving preferences:", error);
     },
   });
 
-  // Initialiser les préférences locales
+  // Initialize local preferences
   useEffect(() => {
-    // Ne pas traiter si les données sont encore en cours de chargement
+    // Skip if data is still loading
     if (isLoading) return;
 
     const prefs: Record<string, boolean> = {};
 
-    // Initialiser avec les valeurs par défaut
+    // Initialize with default values
     categories.forEach((category) => {
       channels.forEach((channel) => {
         const key = `${category.key}-${channel.key}`;
-        // Par défaut, toutes les notifications sont activées
+        // By default, all notifications are enabled
         prefs[key] = true;
       });
     });
 
-    // Appliquer les préférences existantes
+    // Apply existing preferences
     currentPreferences.forEach((pref) => {
       const key = `${pref.category}-${pref.channel}`;
       prefs[key] = pref.enabled;
@@ -147,15 +147,14 @@ export function NotificationPreferences() {
       <div className="max-w-6xl mx-auto p-4 sm:p-6 lg:p-8">
         <div className="mb-6 sm:mb-8">
           <h1 className="text-2xl sm:text-3xl font-bold text-foreground mb-2">
-            Préférences de notifications
+            Notification Preferences
           </h1>
           <p className="text-muted-foreground text-sm sm:text-base">
-            Gérez comment vous souhaitez recevoir les notifications pour chaque
-            type d'événement.
+            Manage how you want to receive notifications for each event type.
           </p>
         </div>
 
-        {/* Version mobile - Cards empilées */}
+        {/* Mobile version - stacked cards */}
         <div className="block md:hidden space-y-4">
           {categories.map((category) => (
             <div
@@ -206,8 +205,8 @@ export function NotificationPreferences() {
                           isEnabled ? "bg-primary" : "bg-muted"
                         }`}
                         title={`${
-                          isEnabled ? "Désactiver" : "Activer"
-                        } les notifications ${channel.label.toLowerCase()}`}
+                          isEnabled ? "Disable" : "Enable"
+                        } ${channel.label.toLowerCase()} notifications`}
                       >
                         <div
                           className={`absolute top-1 w-4 h-4 bg-white rounded-full transition-transform ${
@@ -229,7 +228,7 @@ export function NotificationPreferences() {
           <div className="bg-card/50 border-b border-border p-4 lg:p-6">
             <div className="grid grid-cols-3 gap-4 lg:gap-8">
               <div className="font-semibold text-foreground text-base lg:text-lg">
-                Catégorie
+                Category
               </div>
               {channels.map((channel) => (
                 <div key={channel.key} className="text-center">
@@ -247,7 +246,7 @@ export function NotificationPreferences() {
             </div>
           </div>
 
-          {/* Lignes des catégories */}
+          {/* Category rows */}
           <div className="divide-y divide-border">
             {categories.map((category) => (
               <div
@@ -285,8 +284,8 @@ export function NotificationPreferences() {
                             isEnabled ? "bg-primary" : "bg-muted"
                           }`}
                           title={`${
-                            isEnabled ? "Désactiver" : "Activer"
-                          } les notifications ${channel.label.toLowerCase()} pour ${category.label.toLowerCase()}`}
+                            isEnabled ? "Disable" : "Enable"
+                          } ${channel.label.toLowerCase()} notifications for ${category.label.toLowerCase()}`}
                         >
                           <div
                             className={`absolute top-1 w-4 h-4 lg:w-5 lg:h-5 bg-white rounded-full transition-transform shadow-sm ${
@@ -316,31 +315,29 @@ export function NotificationPreferences() {
               {savePreferencesMutation.isPending ? (
                 <>
                   <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
-                  <span>Sauvegarde...</span>
+                  <span>Saving...</span>
                 </>
               ) : (
                 <>
                   <Save className="w-4 h-4" />
-                  <span>Sauvegarder les préférences</span>
+                  <span>Save preferences</span>
                 </>
               )}
             </button>
           </div>
         )}
 
-        {/* Note informative */}
+        {/* Info note */}
         <div className="mt-8 p-4 bg-muted/30 border border-border rounded-lg">
           <h3 className="font-medium text-foreground mb-2">
-            💡 À propos des notifications
+            💡 About notifications
           </h3>
           <ul className="text-sm text-muted-foreground space-y-1">
             <li>
-              • <strong>Dans l'app</strong> : Notifications visibles dans
-              l'interface utilisateur
+              • <strong>In-app</strong>: Notifications visible in the user interface
             </li>
             <li>
-              • <strong>Email</strong> : Notifications envoyées à votre adresse
-              email
+              • <strong>Email</strong>: Notifications sent to your email address
             </li>
           </ul>
         </div>

--- a/src/pages/NotificationTest.tsx
+++ b/src/pages/NotificationTest.tsx
@@ -6,11 +6,10 @@ export function NotificationTest() {
     <div className="max-w-6xl mx-auto p-6">
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-foreground mb-2">
-          Test des Notifications
+          Notification Test
         </h1>
         <p className="text-muted-foreground">
-          Page de développement pour tester le système de notifications de MTG
-          Artisan.
+          Development page for testing the MTG Artisan notification system.
         </p>
       </div>
 
@@ -18,56 +17,52 @@ export function NotificationTest() {
 
       <div className="mt-8 p-6 bg-card border border-border rounded-lg">
         <h2 className="text-xl font-semibold text-foreground mb-4">
-          Architecture du Système
+          System Architecture
         </h2>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
             <h3 className="font-medium text-foreground mb-3">
-              📊 Tables de Base de Données
+              📊 Database Tables
             </h3>
             <ul className="text-sm text-muted-foreground space-y-1">
               <li>
-                • <code>notification_events</code> - Queue d'événements entrants
+                • <code>notification_events</code> - Incoming event queue
               </li>
               <li>
-                • <code>notifications</code> - Notifications créées pour les
-                utilisateurs
+                • <code>notifications</code> - Notifications created for users
               </li>
               <li>
-                • <code>notification_preferences</code> - Préférences
-                utilisateur
+                • <code>notification_preferences</code> - User preferences
               </li>
               <li>
-                • <code>notification_deliveries</code> - Tâches de livraison
-                (email, push, etc.)
+                • <code>notification_deliveries</code> - Delivery tasks (email, push, etc.)
               </li>
               <li>
-                • <code>notification_templates</code> - Templates de messages
+                • <code>notification_templates</code> - Message templates
               </li>
             </ul>
           </div>
 
           <div>
             <h3 className="font-medium text-foreground mb-3">
-              ⚙️ Fonctions Supabase
+              ⚙️ Supabase Functions
             </h3>
             <ul className="text-sm text-muted-foreground space-y-1">
               <li>
-                • <code>events-emit</code> - Émet un événement
+                • <code>events-emit</code> - Emits an event
               </li>
               <li>
-                • <code>events-fanout</code> - Traite les événements en
-                notifications
+                • <code>events-fanout</code> - Processes events into notifications
               </li>
               <li>
-                • <code>notifications-read</code> - Marque comme lu
+                • <code>notifications-read</code> - Marks as read
               </li>
               <li>
-                • <code>notifications-seen</code> - Marque comme vu
+                • <code>notifications-seen</code> - Marks as seen
               </li>
               <li>
-                • <code>preferences</code> - Gère les préférences
+                • <code>preferences</code> - Manages preferences
               </li>
             </ul>
           </div>
@@ -75,29 +70,27 @@ export function NotificationTest() {
 
         <div className="mt-6 p-4 bg-muted/30 border border-border rounded-lg">
           <h4 className="font-medium text-foreground text-sm mb-2">
-            🔄 Flux de Données
+            🔄 Data Flow
           </h4>
           <ol className="text-xs text-muted-foreground space-y-1">
             <li>
-              1. L'application émet un événement via{" "}
-              <code>NotificationService.emitEvent()</code>
+              1. The application emits an event via <code>NotificationService.emitEvent()</code>
             </li>
             <li>
-              2. L'événement est stocké dans <code>notification_events</code>
+              2. The event is stored in <code>notification_events</code>
             </li>
             <li>
-              3. La fonction <code>events-fanout</code> traite les événements
+              3. The <code>events-fanout</code> function processes the events
             </li>
             <li>
-              4. Les notifications sont créées dans <code>notifications</code>
+              4. Notifications are created in <code>notifications</code>
             </li>
             <li>
-              5. Les tâches de livraison sont créées dans{" "}
-              <code>notification_deliveries</code>
+              5. Delivery tasks are created in <code>notification_deliveries</code>
             </li>
-            <li>6. L'interface React s'abonne aux changements en temps réel</li>
+            <li>6. The React interface subscribes to real-time changes</li>
             <li>
-              7. Les notifications apparaissent dans la cloche et comme toasts
+              7. Notifications appear in the bell and as toasts
             </li>
           </ol>
         </div>


### PR DESCRIPTION
## Summary
- translate notification preference categories and labels to English
- convert notification tester and debug utilities to English
- update notification hooks and test pages to drop remaining French strings

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*

------
https://chatgpt.com/codex/tasks/task_e_68ba6c7a7f5483268d4121bc56bcada1