### PR TITLE
feat: add basic i18n setup with en and fr

### DIFF
--- a/src/components/Cards/ArtistCard.tsx
+++ b/src/components/Cards/ArtistCard.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import {
   MapPin,
   Star,
@@ -32,6 +33,7 @@ export interface ArtistCardProps {
 }
 
 export function ArtistCard({ artist }: ArtistCardProps) {
+  const { t } = useTranslation();
   const totalCreations = artist.products_count + artist.services_count;
   const rating = artist.total_rating || 0;
   const hasRating = rating > 0;
@@ -46,7 +48,7 @@ export function ArtistCard({ artist }: ArtistCardProps) {
         {artist.shop.banner_url ? (
           <img
             src={artist.shop.banner_url}
-            alt={`Bannière de ${artist.shop.name}`}
+            alt={t("artistCard.bannerAlt", { shopName: artist.shop.name })}
             className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700 ease-out"
           />
         ) : (
@@ -61,7 +63,7 @@ export function ArtistCard({ artist }: ArtistCardProps) {
           <div className="absolute top-4 right-4">
             <div className="bg-primary text-primary-foreground text-xs px-3 py-1 rounded-full font-medium flex items-center">
               <Star className="h-3 w-3 mr-1" />
-              Vérifié
+              {t("artistCard.verified")}
             </div>
           </div>
         )}
@@ -118,13 +120,13 @@ export function ArtistCard({ artist }: ArtistCardProps) {
               <div className="flex items-center space-x-2">
                 <Package className="h-4 w-4 text-primary" />
                 <span className="text-sm text-muted-foreground/70">
-                  {artist.products_count} produits
+                  {t("artistCard.products", { count: artist.products_count })}
                 </span>
               </div>
               <div className="flex items-center space-x-2">
                 <Briefcase className="h-4 w-4 text-primary" />
                 <span className="text-sm text-muted-foreground/70">
-                  {artist.services_count} services
+                  {t("artistCard.services", { count: artist.services_count })}
                 </span>
               </div>
             </div>

--- a/src/components/Cards/ServiceCard.tsx
+++ b/src/components/Cards/ServiceCard.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { MessageSquare, Clock, MapPin, Star } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 interface ServiceCardProps {
   service: any;
 }
 
 export function ServiceCard({ service }: ServiceCardProps) {
+  const { t } = useTranslation();
   return (
     <Link to={`/service/${service.id}`} className="group">
       <div className="bg-card rounded-3xl border border-border/30 hover:border-primary/30 transition-all duration-500 hover:scale-[1.02] hover:shadow-2xl hover:shadow-primary/10 p-6">
@@ -40,11 +42,11 @@ export function ServiceCard({ service }: ServiceCardProps) {
           </div>
           <div className="text-right">
             <div className="text-xl font-light text-card-foreground">
-              À partir de ${service.base_price}
+              {t("common.startingFrom")} ${service.base_price}
             </div>
             <div className="flex items-center text-xs text-muted-foreground/60 mt-1">
               <Clock className="h-3 w-3 mr-1" />
-              {service.delivery_days} jours
+              {t("common.days", { count: service.delivery_days })}
             </div>
           </div>
         </div>
@@ -64,17 +66,19 @@ export function ServiceCard({ service }: ServiceCardProps) {
             <MessageSquare className="h-4 w-4 mr-2" />
             <span className="hidden sm:inline">
               {service.requires_brief
-                ? "Consultation requise"
-                : "Commande rapide"}
+                ? t("serviceCard.requiresBrief")
+                : t("serviceCard.quickOrder")}
             </span>
             <span className="sm:hidden">
-              {service.requires_brief ? "Consult" : "Rapide"}
+              {service.requires_brief
+                ? t("serviceCard.requiresBriefShort")
+                : t("serviceCard.quickOrderShort")}
             </span>
           </div>
 
           <div className="flex items-center text-sm text-muted-foreground/70">
             <Star className="h-4 w-4 mr-2 text-primary/60" />
-            {service.shop?.rating_avg || "Nouveau"}
+            {service.shop?.rating_avg || t("common.new")}
           </div>
         </div>
 

--- a/src/components/Checkout/CheckoutSummary.tsx
+++ b/src/components/Checkout/CheckoutSummary.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Card, CardHeader, CardContent } from "../UI/Card";
 
 interface CheckoutSummaryProps {
@@ -14,6 +15,7 @@ export function CheckoutSummary({
   shippingRequired,
   isShippingComplete,
 }: CheckoutSummaryProps) {
+  const { t } = useTranslation();
   // Group items by shop
   const itemsByShop = items.reduce((acc, item) => {
     if (!acc[item.shop_id]) {
@@ -30,7 +32,7 @@ export function CheckoutSummary({
     <Card className="sticky top-24">
       <CardHeader>
         <h2 className="text-2xl font-light text-foreground tracking-tight">
-          Résumé de la commande
+          {t("checkoutSummary.title")}
         </h2>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -56,7 +58,7 @@ export function CheckoutSummary({
                         />
                       ) : (
                         <div className="w-full h-full flex items-center justify-center text-muted-foreground text-xs text-center">
-                          No Image
+                          {t("checkoutSummary.noImage")}
                         </div>
                       )}
                     </div>
@@ -92,7 +94,7 @@ export function CheckoutSummary({
 
         {shippingRequired && !isShippingComplete && (
           <p className="text-sm text-destructive">
-            Veuillez compléter l'adresse de livraison pour continuer.
+            {t("checkoutSummary.completeShipping")}
           </p>
         )}
       </CardContent>

--- a/src/components/Creator/ProductsTable.tsx
+++ b/src/components/Creator/ProductsTable.tsx
@@ -4,6 +4,7 @@ import { Button, Card, CardContent, CardHeader, EmptyState } from "../UI";
 import { useShopStatistics } from "../../hooks/useAnalytics";
 import { Product, ProductWithStats, Category } from "../../types";
 import supabase from "../../lib/supabase";
+import { useTranslation } from "react-i18next";
 import {
   Edit3,
   Eye,
@@ -27,6 +28,7 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
   >([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   const {
     statistics,
@@ -50,8 +52,8 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
       if (error) throw error;
       setProducts(data || []);
     } catch (error) {
-      console.error("Erreur lors de la récupération des produits:", error);
-      toast.error("Impossible de charger les produits");
+      console.error("Error fetching products:", error);
+      toast.error(t("productsTable.loadError"));
     }
   };
 
@@ -95,13 +97,13 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
       if (error) throw error;
       setCategories(data || []);
     } catch (error) {
-      console.error("Erreur lors de la récupération des catégories:", error);
+      console.error("Error fetching categories:", error);
     }
   };
 
   const getCategoryName = (categoryId: string) => {
     const category = categories.find((cat) => cat.id === categoryId);
-    return category?.name || "Sans catégorie";
+    return category?.name || t("common.noCategory");
   };
 
   const getStatusColor = (status: string) => {
@@ -122,13 +124,13 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
   const getStatusLabel = (status: string) => {
     switch (status) {
       case "active":
-        return "Actif";
+        return t("common.status.active");
       case "draft":
-        return "Brouillon";
+        return t("common.status.draft");
       case "paused":
-        return "En pause";
+        return t("common.status.paused");
       case "sold_out":
-        return "Épuisé";
+        return t("common.status.sold_out");
       default:
         return status;
     }
@@ -137,7 +139,7 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
   const deleteProduct = async (productId: string, productTitle: string) => {
     if (
       !window.confirm(
-        `Êtes-vous sûr de vouloir supprimer le produit "${productTitle}" ? Cette action est irréversible.`
+        t("productsTable.confirmDelete", { title: productTitle })
       )
     ) {
       return;
@@ -151,12 +153,12 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
 
       if (error) throw error;
 
-      toast.success("Produit supprimé avec succès");
+      toast.success(t("productsTable.deleteSuccess"));
       fetchProducts(); // Recharger la liste
       refetch(); // Recharger les statistiques
     } catch (error: any) {
-      console.error("Erreur lors de la suppression:", error);
-      toast.error(error.message || "Impossible de supprimer le produit");
+      console.error("Error deleting:", error);
+      toast.error(error.message || t("productsTable.deleteError"));
     }
   };
 
@@ -178,11 +180,11 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
         <CardHeader>
           <div className="flex items-center justify-between">
             <h2 className="text-2xl font-light text-foreground tracking-tight">
-              Mes Produits
+              {t("productsTable.heading")}
             </h2>
             <Link to="/creator/products/new">
               <Button variant="primary" size="sm" icon={Package}>
-                Créer un produit
+                {t("productsTable.create")}
               </Button>
             </Link>
           </div>
@@ -190,9 +192,9 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
         <CardContent>
           <EmptyState
             icon={Package}
-            title="Aucun produit créé"
-            description="Créez votre premier produit pour commencer à vendre vos créations"
-            actionLabel="Créer mon premier produit"
+            title={t("productsTable.emptyTitle")}
+            description={t("productsTable.emptyDescription")}
+            actionLabel={t("productsTable.emptyAction")}
             actionIcon={Package}
             onAction={() => navigate("/creator/products/new")}
           />
@@ -206,11 +208,11 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
       <CardHeader>
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
           <h2 className="text-2xl font-light text-foreground tracking-tight">
-            Mes Produits ({productsWithStats.length})
+            {t("productsTable.headingCount", { count: productsWithStats.length })}
           </h2>
           <Link to="/creator/products/new">
             <Button variant="primary" size="sm" icon={Package}>
-              Créer un produit
+              {t("productsTable.create")}
             </Button>
           </Link>
         </div>
@@ -248,8 +250,8 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
                       <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
                         <span className="bg-muted/20 px-2 py-1 rounded-full">
                           {product.type === "physical"
-                            ? "Physique"
-                            : "Numérique"}
+                            ? t("common.types.physical")
+                            : t("common.types.digital")}
                         </span>
                         <span className="bg-muted/20 px-2 py-1 rounded-full">
                           {getCategoryName(product.category_id)}
@@ -266,10 +268,10 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
                                 : "bg-red-500/20 text-red-500"
                             }`}
                           >
-                            Stock total: {product.stock}
+                            {t("common.stockTotal")}: {product.stock}
                             {product.currently_in_carts > 0 && (
                               <span className="ml-1 opacity-70">
-                                ({product.currently_in_carts} en paniers)
+                                ({t("common.inCarts", { count: product.currently_in_carts })})
                               </span>
                             )}
                           </span>
@@ -285,7 +287,7 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
                     <div className="text-xl font-light text-foreground">
                       ${product.price}
                     </div>
-                    <div className="text-xs text-muted-foreground">Prix</div>
+                    <div className="text-xs text-muted-foreground">{t("common.price")}</div>
                   </div>
                 </div>
 
@@ -307,16 +309,15 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
                         {product.stock}
                       </div>
                       <div className="text-xs text-muted-foreground">
-                        Stock total
+                        {t("common.stockTotal")}
                         {product.currently_in_carts > 0 && (
                           <div className="text-xs text-orange-500 mt-1">
-                            {product.currently_in_carts} en paniers
+                            {t("common.inCarts", { count: product.currently_in_carts })}
                           </div>
                         )}
                       </div>
                       <div className="text-xs text-muted-foreground mt-1">
-                        Disponible:{" "}
-                        {Math.max(
+                        {t("common.available")}: {Math.max(
                           0,
                           product.stock - product.currently_in_carts
                         )}
@@ -326,7 +327,7 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
                     <div className="text-center">
                       <div className="text-sm text-muted-foreground">∞</div>
                       <div className="text-xs text-muted-foreground">
-                        Illimité
+                        {t("common.unlimited")}
                       </div>
                     </div>
                   )}
@@ -342,7 +343,7 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
                           {product.total_views}
                         </span>
                       </div>
-                      <div className="text-xs text-muted-foreground">Vues</div>
+                      <div className="text-xs text-muted-foreground">{t("common.views")}</div>
                     </div>
                     <div>
                       <div className="flex items-center justify-center mb-1">
@@ -352,7 +353,7 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
                         </span>
                       </div>
                       <div className="text-xs text-muted-foreground">
-                        Ventes
+                        {t("common.sales")}
                       </div>
                     </div>
                     <div>
@@ -363,7 +364,7 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
                         </span>
                       </div>
                       <div className="text-xs text-muted-foreground">
-                        Revenus
+                        {t("common.revenue")}
                       </div>
                     </div>
                   </div>
@@ -373,7 +374,7 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
                 <div className="lg:col-span-1 flex lg:flex-col gap-2 lg:items-center lg:justify-center">
                   <Link to={`/creator/products/${product.id}/edit`}>
                     <Button variant="outline" size="sm" icon={Edit3}>
-                      <span className="sr-only">Éditer</span>
+                      <span className="sr-only">{t("common.edit")}</span>
                     </Button>
                   </Link>
                   <Button
@@ -382,7 +383,7 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
                     icon={ExternalLink}
                     onClick={() => navigate(`/product/${product.id}`)}
                   >
-                    <span className="sr-only">Voir</span>
+                    <span className="sr-only">{t("common.view")}</span>
                   </Button>
                   <Button
                     variant="outline"
@@ -391,7 +392,7 @@ export function ProductsTable({ shopId }: ProductsTableProps) {
                     onClick={() => deleteProduct(product.id, product.title)}
                     className="text-red-500 hover:text-red-600 hover:border-red-500/30"
                   >
-                    <span className="sr-only">Supprimer</span>
+                    <span className="sr-only">{t("common.delete")}</span>
                   </Button>
                 </div>
               </div>

--- a/src/components/Creator/ServicesTable.tsx
+++ b/src/components/Creator/ServicesTable.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Button, Card, CardContent, CardHeader, EmptyState } from "../UI";
 import supabase from "../../lib/supabase";
+import { useTranslation } from "react-i18next";
 import {
   Edit3,
   Eye,
@@ -38,6 +39,7 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
   const [loading, setLoading] = useState(true);
   const [categories, setCategories] = useState<any[]>([]);
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   useEffect(() => {
     fetchServices();
@@ -64,8 +66,8 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
 
       setServices(servicesWithStats);
     } catch (error) {
-      console.error("Erreur lors de la récupération des services:", error);
-      toast.error("Impossible de charger les services");
+      console.error("Error fetching services:", error);
+      toast.error(t("servicesTable.loadError"));
     } finally {
       setLoading(false);
     }
@@ -81,14 +83,14 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
       if (error) throw error;
       setCategories(data || []);
     } catch (error) {
-      console.error("Erreur lors de la récupération des catégories:", error);
+      console.error("Error fetching categories:", error);
     }
   };
 
   const getCategoryName = (categoryId: string | null) => {
-    if (!categoryId) return "Sans catégorie";
+    if (!categoryId) return t("common.noCategory");
     const category = categories.find((cat) => cat.id === categoryId);
-    return category?.name || "Sans catégorie";
+    return category?.name || t("common.noCategory");
   };
 
   const getStatusColor = (status: string) => {
@@ -107,11 +109,11 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
   const getStatusLabel = (status: string) => {
     switch (status) {
       case "active":
-        return "Actif";
+        return t("common.status.active");
       case "draft":
-        return "Brouillon";
+        return t("common.status.draft");
       case "paused":
-        return "En pause";
+        return t("common.status.paused");
       default:
         return status;
     }
@@ -120,7 +122,7 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
   const deleteService = async (serviceId: string, serviceTitle: string) => {
     if (
       !window.confirm(
-        `Êtes-vous sûr de vouloir supprimer le service "${serviceTitle}" ? Cette action est irréversible.`
+        t("servicesTable.confirmDelete", { title: serviceTitle })
       )
     ) {
       return;
@@ -134,11 +136,11 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
 
       if (error) throw error;
 
-      toast.success("Service supprimé avec succès");
+      toast.success(t("servicesTable.deleteSuccess"));
       fetchServices(); // Recharger la liste
     } catch (error: any) {
-      console.error("Erreur lors de la suppression:", error);
-      toast.error(error.message || "Impossible de supprimer le service");
+      console.error("Error deleting:", error);
+      toast.error(error.message || t("servicesTable.deleteError"));
     }
   };
 
@@ -160,11 +162,11 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
         <CardHeader>
           <div className="flex items-center justify-between">
             <h2 className="text-2xl font-light text-foreground tracking-tight">
-              Mes Services
+              {t("servicesTable.heading")}
             </h2>
             <Link to="/creator/services/new">
               <Button variant="primary" size="sm" icon={Briefcase}>
-                Créer un service
+                {t("servicesTable.create")}
               </Button>
             </Link>
           </div>
@@ -172,9 +174,9 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
         <CardContent>
           <EmptyState
             icon={Briefcase}
-            title="Aucun service créé"
-            description="Créez votre premier service pour proposer vos compétences et services"
-            actionLabel="Créer mon premier service"
+            title={t("servicesTable.emptyTitle")}
+            description={t("servicesTable.emptyDescription")}
+            actionLabel={t("servicesTable.emptyAction")}
             actionIcon={Briefcase}
             onAction={() => navigate("/creator/services/new")}
           />
@@ -188,11 +190,11 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
       <CardHeader>
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
           <h2 className="text-2xl font-light text-foreground tracking-tight">
-            Mes Services ({services.length})
+            {t("servicesTable.headingCount", { count: services.length })}
           </h2>
           <Link to="/creator/services/new">
             <Button variant="primary" size="sm" icon={Briefcase}>
-              Créer un service
+              {t("servicesTable.create")}
             </Button>
           </Link>
         </div>
@@ -232,12 +234,11 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
                           {getCategoryName(service.category_id)}
                         </span>
                         <span className="bg-muted/20 px-2 py-1 rounded-full">
-                          {service.delivery_days} jour
-                          {service.delivery_days > 1 ? "s" : ""}
+                          {t("common.days", { count: service.delivery_days })}
                         </span>
                         {service.requires_brief && (
                           <span className="bg-muted/20 px-2 py-1 rounded-full">
-                            Brief requis
+                            {t("common.briefRequired")}
                           </span>
                         )}
                       </div>
@@ -252,7 +253,7 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
                       ${service.base_price}
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      À partir de
+                      {t("common.startingFrom")}
                     </div>
                   </div>
                 </div>
@@ -267,7 +268,7 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
                           {service.views}
                         </span>
                       </div>
-                      <div className="text-xs text-muted-foreground">Vues</div>
+                      <div className="text-xs text-muted-foreground">{t("common.views")}</div>
                     </div>
                     <div>
                       <div className="flex items-center justify-center mb-1">
@@ -277,7 +278,7 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
                         </span>
                       </div>
                       <div className="text-xs text-muted-foreground">
-                        Commandes
+                        {t("common.orders")}
                       </div>
                     </div>
                     <div>
@@ -288,7 +289,7 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
                         </span>
                       </div>
                       <div className="text-xs text-muted-foreground">
-                        Revenus
+                        {t("common.revenue")}
                       </div>
                     </div>
                   </div>
@@ -301,10 +302,10 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
                     size="sm"
                     icon={Edit3}
                     onClick={() =>
-                      toast.info("Page d'édition de service à venir")
+                      toast.info(t("servicesTable.editComingSoon"))
                     }
                   >
-                    <span className="sr-only">Éditer</span>
+                    <span className="sr-only">{t("common.edit")}</span>
                   </Button>
                   <Button
                     variant="outline"
@@ -312,7 +313,7 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
                     icon={ExternalLink}
                     onClick={() => navigate(`/service/${service.id}`)}
                   >
-                    <span className="sr-only">Voir</span>
+                    <span className="sr-only">{t("common.view")}</span>
                   </Button>
                   <Button
                     variant="outline"
@@ -321,7 +322,7 @@ export function ServicesTable({ shopId }: ServicesTableProps) {
                     onClick={() => deleteService(service.id, service.title)}
                     className="text-red-500 hover:text-red-600 hover:border-red-500/30"
                   >
-                    <span className="sr-only">Supprimer</span>
+                    <span className="sr-only">{t("common.delete")}</span>
                   </Button>
                 </div>
               </div>

--- a/src/components/Creator/ShippingManager.tsx
+++ b/src/components/Creator/ShippingManager.tsx
@@ -3,6 +3,7 @@ import { Button, Card, CardContent, CardHeader, Input, Select } from "../UI";
 import supabase from "../../lib/supabase";
 import { Truck, Plus, Edit3, Trash2, Globe } from "lucide-react";
 import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
 
 interface ShippingProfile {
   id: string;
@@ -33,9 +34,11 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
   const [zones, setZones] = useState<ShippingZone[]>([]);
   const [loading, setLoading] = useState(true);
   const [editingProfile, setEditingProfile] = useState<ShippingProfile | null>(
-    null
+    null,
   );
   const [showNewProfile, setShowNewProfile] = useState(false);
+
+  const { t } = useTranslation();
 
   const [newProfile, setNewProfile] = useState({
     name: "",
@@ -69,11 +72,8 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
       setProfiles(profilesResult.data || []);
       setZones(zonesResult.data || []);
     } catch (error) {
-      console.error(
-        "Erreur lors du chargement des données de livraison:",
-        error
-      );
-      toast.error("Impossible de charger les paramètres de livraison");
+      console.error(t("shippingManager.errors.load"), error);
+      toast.error(t("shippingManager.errors.load"));
     } finally {
       setLoading(false);
     }
@@ -81,7 +81,7 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
 
   const createProfile = async () => {
     if (!newProfile.name.trim()) {
-      toast.error("Le nom du profil est requis");
+      toast.error(t("shippingManager.errors.nameRequired"));
       return;
     }
 
@@ -97,7 +97,7 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
 
       if (error) throw error;
 
-      toast.success("Profil de livraison créé");
+      toast.success(t("shippingManager.success.create"));
       setShowNewProfile(false);
       setNewProfile({
         name: "",
@@ -108,13 +108,16 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
       });
       fetchShippingData();
     } catch (error: any) {
-      console.error("Erreur lors de la création:", error);
-      toast.error(error.message || "Impossible de créer le profil");
+      console.error(t("shippingManager.errors.create"), error);
+      toast.error(error.message || t("shippingManager.errors.create"));
     }
   };
 
   const deleteProfile = async (profileId: string, profileName: string) => {
-    if (!window.confirm(`Supprimer le profil "${profileName}" ?`)) return;
+    if (
+      !window.confirm(t("shippingManager.confirmDelete", { name: profileName }))
+    )
+      return;
 
     try {
       const { error } = await supabase
@@ -124,11 +127,11 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
 
       if (error) throw error;
 
-      toast.success("Profil supprimé");
+      toast.success(t("shippingManager.success.delete"));
       fetchShippingData();
     } catch (error: any) {
-      console.error("Erreur lors de la suppression:", error);
-      toast.error(error.message || "Impossible de supprimer le profil");
+      console.error(t("shippingManager.errors.delete"), error);
+      toast.error(error.message || t("shippingManager.errors.delete"));
     }
   };
 
@@ -148,11 +151,11 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
 
       if (error) throw error;
 
-      toast.success("Profil par défaut mis à jour");
+      toast.success(t("shippingManager.success.updateDefault"));
       fetchShippingData();
     } catch (error: any) {
-      console.error("Erreur lors de la mise à jour:", error);
-      toast.error(error.message || "Impossible de mettre à jour le profil");
+      console.error(t("shippingManager.errors.update"), error);
+      toast.error(error.message || t("shippingManager.errors.update"));
     }
   };
 
@@ -176,7 +179,7 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
             <div className="flex items-center gap-3">
               <Truck className="h-6 w-6 text-primary" />
               <h2 className="text-2xl font-light text-foreground tracking-tight">
-                Frais de Livraison
+                {t("shippingManager.title")}
               </h2>
             </div>
             <Button
@@ -185,7 +188,7 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
               icon={Plus}
               onClick={() => setShowNewProfile(true)}
             >
-              Nouveau profil
+              {t("shippingManager.newProfile")}
             </Button>
           </div>
         </CardHeader>
@@ -195,19 +198,19 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
           {showNewProfile && (
             <div className="mb-6 p-4 border border-border/30 rounded-2xl bg-card/30">
               <h3 className="text-lg font-medium text-foreground mb-4">
-                Nouveau profil de livraison
+                {t("shippingManager.newProfileTitle")}
               </h3>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <Input
-                  label="Nom du profil *"
+                  label={t("shippingManager.nameLabel")}
                   value={newProfile.name}
                   onChange={(e) =>
                     setNewProfile({ ...newProfile, name: e.target.value })
                   }
-                  placeholder="ex: Livraison Standard"
+                  placeholder={t("shippingManager.namePlaceholder")}
                 />
                 <Input
-                  label="Coût de base (€)"
+                  label={t("shippingManager.baseCostLabel")}
                   type="number"
                   min="0"
                   step="0.01"
@@ -220,7 +223,7 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
                   }
                 />
                 <Input
-                  label="Description"
+                  label={t("shippingManager.descriptionLabel")}
                   value={newProfile.description}
                   onChange={(e) =>
                     setNewProfile({
@@ -228,10 +231,10 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
                       description: e.target.value,
                     })
                   }
-                  placeholder="Description optionnelle"
+                  placeholder={t("shippingManager.descriptionPlaceholder")}
                 />
                 <Input
-                  label="Livraison gratuite à partir de (€)"
+                  label={t("shippingManager.freeShippingLabel")}
                   type="number"
                   min="0"
                   step="0.01"
@@ -244,7 +247,7 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
                         : null,
                     })
                   }
-                  placeholder="Optionnel"
+                  placeholder={t("shippingManager.freeShippingPlaceholder")}
                 />
               </div>
               <div className="flex items-center gap-2 mt-4">
@@ -261,7 +264,7 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
                   className="rounded border-border/50 text-primary focus:ring-primary/20"
                 />
                 <label htmlFor="is_default" className="text-sm text-foreground">
-                  Définir comme profil par défaut
+                  {t("shippingManager.defaultLabel")}
                 </label>
               </div>
               <div className="flex justify-end gap-3 mt-4">
@@ -269,10 +272,10 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
                   variant="ghost"
                   onClick={() => setShowNewProfile(false)}
                 >
-                  Annuler
+                  {t("shippingManager.cancel")}
                 </Button>
                 <Button variant="primary" onClick={createProfile}>
-                  Créer le profil
+                  {t("shippingManager.create")}
                 </Button>
               </div>
             </div>
@@ -283,10 +286,10 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
             <div className="text-center py-8">
               <Truck className="h-12 w-12 text-muted-foreground/40 mx-auto mb-3" />
               <p className="text-muted-foreground">
-                Aucun profil de livraison configuré
+                {t("shippingManager.noProfiles")}
               </p>
               <p className="text-sm text-muted-foreground/70 mt-1">
-                Créez votre premier profil pour définir vos frais de livraison
+                {t("shippingManager.createFirst")}
               </p>
             </div>
           ) : (
@@ -308,7 +311,7 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
                         </h3>
                         {profile.is_default && (
                           <span className="bg-primary/20 text-primary text-xs px-2 py-1 rounded-full border border-primary/30">
-                            Par défaut
+                            {t("shippingManager.defaultTag")}
                           </span>
                         )}
                       </div>
@@ -318,10 +321,12 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
                         </p>
                       )}
                       <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
-                        <span>Coût de base: {profile.base_cost}€</span>
+                        <span>
+                          {t("shippingManager.baseCost")} {profile.base_cost}€
+                        </span>
                         {profile.free_shipping_threshold && (
                           <span>
-                            Gratuit à partir de:{" "}
+                            {t("shippingManager.freeFrom")}{" "}
                             {profile.free_shipping_threshold}€
                           </span>
                         )}
@@ -334,7 +339,7 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
                           size="sm"
                           onClick={() => setDefaultProfile(profile.id)}
                         >
-                          Par défaut
+                          {t("shippingManager.setDefault")}
                         </Button>
                       )}
                       <Button
@@ -344,7 +349,7 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
                         onClick={() => deleteProfile(profile.id, profile.name)}
                         className="text-red-500 hover:text-red-600"
                       >
-                        <span className="sr-only">Supprimer</span>
+                        <span className="sr-only">{t("common.delete")}</span>
                       </Button>
                     </div>
                   </div>
@@ -362,25 +367,13 @@ export function ShippingManager({ shopId }: ShippingManagerProps) {
             <Globe className="h-5 w-5 text-primary mt-0.5" />
             <div>
               <h3 className="font-medium text-foreground mb-2">
-                Comment ça marche ?
+                {t("shippingManager.howItWorks.title")}
               </h3>
               <div className="text-sm text-muted-foreground space-y-1">
-                <p>
-                  • Le profil par défaut sera appliqué à toutes les nouvelles
-                  commandes
-                </p>
-                <p>
-                  • Les frais de livraison sont calculés automatiquement lors du
-                  checkout
-                </p>
-                <p>
-                  • La livraison gratuite s'applique si le montant dépasse le
-                  seuil défini
-                </p>
-                <p>
-                  • Vous pouvez créer plusieurs profils pour différents types de
-                  produits
-                </p>
+                <p>{t("shippingManager.howItWorks.default")}</p>
+                <p>{t("shippingManager.howItWorks.calc")}</p>
+                <p>{t("shippingManager.howItWorks.free")}</p>
+                <p>{t("shippingManager.howItWorks.multiple")}</p>
               </div>
             </div>
           </div>

--- a/src/components/Creator/StockAlerts.tsx
+++ b/src/components/Creator/StockAlerts.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { Button, Card, CardContent, CardHeader } from "../UI";
 import { Product, ProductStatistics } from "../../types";
 import { AlertTriangle, Package, Edit3 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import supabase from "../../lib/supabase";
 
 interface LowStockProduct extends Product {
@@ -15,6 +16,7 @@ interface StockAlertsProps {
 }
 
 export function StockAlerts({ shopId }: StockAlertsProps) {
+  const { t } = useTranslation();
   const [lowStockProducts, setLowStockProducts] = useState<LowStockProduct[]>(
     []
   );
@@ -89,7 +91,7 @@ export function StockAlerts({ shopId }: StockAlertsProps) {
         <div className="flex items-center gap-3">
           <AlertTriangle className="h-5 w-5 text-orange-500" />
           <h3 className="text-lg font-medium text-foreground">
-            Alertes Stock ({lowStockProducts.length})
+            {t("stockAlerts.title", { count: lowStockProducts.length })}
           </h3>
         </div>
       </CardHeader>
@@ -108,13 +110,15 @@ export function StockAlerts({ shopId }: StockAlertsProps) {
                   </p>
                   <p className="text-xs text-orange-600">
                     {product.available_stock === 0
-                      ? "Rupture de stock"
-                      : `Plus que ${product.available_stock} disponible${
-                          product.available_stock > 1 ? "s" : ""
-                        }`}
+                      ? t("stockAlerts.outOfStock")
+                      : t("stockAlerts.remaining", {
+                          count: product.available_stock,
+                        })}
                     {product.currently_in_carts > 0 && (
                       <span className="ml-2">
-                        ({product.currently_in_carts} en paniers)
+                        {t("stockAlerts.inCarts", {
+                          count: product.currently_in_carts,
+                        })}
                       </span>
                     )}
                   </p>
@@ -122,7 +126,7 @@ export function StockAlerts({ shopId }: StockAlertsProps) {
               </div>
               <Link to={`/creator/products/${product.id}/edit`}>
                 <Button variant="outline" size="sm" icon={Edit3}>
-                  Gérer
+                  {t("stockAlerts.manage")}
                 </Button>
               </Link>
             </div>

--- a/src/components/Creator/StockInfoCard.tsx
+++ b/src/components/Creator/StockInfoCard.tsx
@@ -1,19 +1,21 @@
 import React from "react";
 import { Card, CardContent, CardHeader } from "../UI";
 import { Info, Package, ShoppingCart } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 interface StockInfoCardProps {
   className?: string;
 }
 
 export function StockInfoCard({ className = "" }: StockInfoCardProps) {
+  const { t } = useTranslation();
   return (
     <Card className={`border-blue-500/30 bg-blue-500/5 ${className}`}>
       <CardHeader>
         <div className="flex items-center gap-3">
           <Info className="h-5 w-5 text-blue-500" />
           <h3 className="text-lg font-medium text-foreground">
-            Comment fonctionne la gestion du stock ?
+            {t("stockInfoCard.title")}
           </h3>
         </div>
       </CardHeader>
@@ -23,11 +25,10 @@ export function StockInfoCard({ className = "" }: StockInfoCardProps) {
             <Package className="h-5 w-5 text-blue-500 mt-0.5" />
             <div>
               <h4 className="text-sm font-medium text-foreground mb-1">
-                Stock Total en Inventaire
+                {t("stockInfoCard.totalTitle")}
               </h4>
               <p className="text-xs text-muted-foreground">
-                C'est le nombre total d'articles que vous avez en stock. Vous
-                pouvez le modifier dans l'édition du produit.
+                {t("stockInfoCard.totalDesc")}
               </p>
             </div>
           </div>
@@ -36,44 +37,44 @@ export function StockInfoCard({ className = "" }: StockInfoCardProps) {
             <ShoppingCart className="h-5 w-5 text-orange-500 mt-0.5" />
             <div>
               <h4 className="text-sm font-medium text-foreground mb-1">
-                Articles en Paniers
+                {t("stockInfoCard.inCartsTitle")}
               </h4>
               <p className="text-xs text-muted-foreground">
-                Nombre d'articles actuellement dans les paniers des clients
-                (mais pas encore achetés).
+                {t("stockInfoCard.inCartsDesc")}
               </p>
             </div>
           </div>
 
           <div className="bg-muted/20 rounded-lg p-3">
             <h4 className="text-sm font-medium text-foreground mb-2">
-              📊 Calcul du Stock Disponible
+              {t("stockInfoCard.calcTitle")}
             </h4>
             <div className="text-xs text-muted-foreground space-y-1">
               <div className="flex justify-between">
-                <span>Stock total :</span>
-                <span className="font-mono">10 articles</span>
+                <span>{t("stockInfoCard.total")}</span>
+                <span className="font-mono">
+                  10 {t("stockInfoCard.items", { count: 10 })}
+                </span>
               </div>
               <div className="flex justify-between">
-                <span>En paniers :</span>
-                <span className="font-mono text-orange-500">-3 articles</span>
+                <span>{t("stockInfoCard.inCarts")}</span>
+                <span className="font-mono text-orange-500">
+                  -3 {t("stockInfoCard.items", { count: 3 })}
+                </span>
               </div>
               <div className="flex justify-between border-t border-border/30 pt-1 mt-1">
-                <span className="font-medium">Disponible :</span>
+                <span className="font-medium">
+                  {t("stockInfoCard.available")}
+                </span>
                 <span className="font-mono font-medium text-green-500">
-                  7 articles
+                  7 {t("stockInfoCard.items", { count: 7 })}
                 </span>
               </div>
             </div>
           </div>
 
           <div className="text-xs text-muted-foreground">
-            <p>
-              💡 <strong>Conseil :</strong> Le stock disponible est affiché en
-              temps réel aux clients. Si un client ajoute un article à son
-              panier, le stock disponible diminue immédiatement pour les autres
-              clients.
-            </p>
+            <p>{t("stockInfoCard.tip")}</p>
           </div>
         </div>
       </CardContent>

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { Sparkles, Github, Twitter, MessageCircle, Heart } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 export function Footer() {
+  const { t } = useTranslation();
+
   return (
     <footer className="glass border-t border-border/30 mt-auto">
       <div className="max-w-7xl mx-auto px-6 lg:px-8 py-16">
@@ -19,9 +22,7 @@ export function Footer() {
               </span>
             </Link>
             <p className="text-muted-foreground/80 max-w-md leading-relaxed text-sm">
-              Les boutiques d'art de référence pour l'art personnalisé Magic: The
-              Gathering, les alters, tokens et créations uniques.
-              Découvrez des artistes talentueux du monde entier.
+              {t("footer.description")}
             </p>
             <div className="flex space-x-4 mt-8">
               <a
@@ -48,7 +49,7 @@ export function Footer() {
           {/* Boutiques */}
           <div>
             <h3 className="text-foreground font-light text-lg mb-6 tracking-wide">
-              Boutiques
+              {t("footer.sections.shops.title")}
             </h3>
             <ul className="space-y-3">
               <li>
@@ -56,7 +57,7 @@ export function Footer() {
                   to="/search?category=Card+Alters"
                   className="text-muted-foreground/70 hover:text-primary transition-colors duration-300 text-sm"
                 >
-                  Card Alters
+                  {t("footer.sections.shops.cardAlters")}
                 </Link>
               </li>
               <li>
@@ -64,7 +65,7 @@ export function Footer() {
                   to="/search?category=Custom+Tokens"
                   className="text-muted-foreground/70 hover:text-primary transition-colors duration-300 text-sm"
                 >
-                  Custom Tokens
+                  {t("footer.sections.shops.customTokens")}
                 </Link>
               </li>
               <li>
@@ -72,7 +73,7 @@ export function Footer() {
                   to="/search?category=Playmats"
                   className="text-muted-foreground/70 hover:text-primary transition-colors duration-300 text-sm"
                 >
-                  Playmats
+                  {t("footer.sections.shops.playmats")}
                 </Link>
               </li>
               <li>
@@ -80,7 +81,7 @@ export function Footer() {
                   to="/search?type=service&category=Deckbuilding"
                   className="text-muted-foreground/70 hover:text-primary transition-colors duration-300 text-sm"
                 >
-                  Artisans de Deckbuilding
+                  {t("footer.sections.shops.deckbuilding")}
                 </Link>
               </li>
             </ul>
@@ -89,7 +90,7 @@ export function Footer() {
           {/* Support */}
           <div>
             <h3 className="text-foreground font-light text-lg mb-6 tracking-wide">
-              Support
+              {t("footer.sections.support.title")}
             </h3>
             <ul className="space-y-3">
               <li>
@@ -97,7 +98,7 @@ export function Footer() {
                   to="/help"
                   className="text-muted-foreground/70 hover:text-primary transition-colors duration-300 text-sm"
                 >
-                  Centre d'aide
+                  {t("footer.sections.support.helpCenter")}
                 </Link>
               </li>
               <li>
@@ -105,7 +106,7 @@ export function Footer() {
                   to="/seller-guide"
                   className="text-muted-foreground/70 hover:text-primary transition-colors duration-300 text-sm"
                 >
-                  Guide du vendeur
+                  {t("footer.sections.support.sellerGuide")}
                 </Link>
               </li>
               <li>
@@ -113,7 +114,7 @@ export function Footer() {
                   to="/terms"
                   className="text-muted-foreground/70 hover:text-primary transition-colors duration-300 text-sm"
                 >
-                  Conditions d'utilisation
+                  {t("footer.sections.support.terms")}
                 </Link>
               </li>
               <li>
@@ -121,7 +122,7 @@ export function Footer() {
                   to="/privacy"
                   className="text-muted-foreground/70 hover:text-primary transition-colors duration-300 text-sm"
                 >
-                  Politique de confidentialité
+                  {t("footer.sections.support.privacy")}
                 </Link>
               </li>
             </ul>
@@ -130,12 +131,11 @@ export function Footer() {
 
         <div className="border-t border-border/30 mt-12 pt-8 text-center">
           <p className="text-muted-foreground/60 text-sm">
-            &copy; 2025 ManaShop. Tous droits réservés.
+            &copy; 2025 ManaShop. {t("footer.rights")}
             <span className="mx-2">•</span>
-            Magic: The Gathering est une marque déposée de Wizards of the Coast.
+            {t("footer.trademark")}
             <span className="mx-2">•</span>
-            Fait avec <Heart className="inline h-4 w-4 text-primary/60" /> par
-            des passionnés
+            {t("footer.madeWith")} <Heart className="inline h-4 w-4 text-primary/60" /> {t("footer.byFans")}
           </p>
         </div>
       </div>

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -2,8 +2,10 @@ import React, { useState, useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
 import { Search, Sparkles, Menu, X } from "lucide-react";
 import { UserMenu } from "./UserMenu";
+import { useTranslation } from "react-i18next";
 
 export function Header() {
+  const { t } = useTranslation();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const mobileMenuRef = useRef<HTMLDivElement>(null);
 
@@ -50,13 +52,13 @@ export function Header() {
               to="/search"
               className="text-foreground/80 hover:text-primary transition-colors duration-300"
             >
-              Boutiques
+              {t("header.shops")}
             </Link>
             <Link
               to="/search?type=services"
               className="text-foreground/80 hover:text-primary transition-colors duration-300"
             >
-              Artisans
+              {t("header.artisans")}
             </Link>
           </nav>
 
@@ -66,7 +68,7 @@ export function Header() {
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground/60" />
               <input
                 type="text"
-                placeholder="Rechercher des créations..."
+                placeholder={t("header.searchPlaceholder")}
                 className="w-full bg-card/50 border border-border/50 rounded-2xl pl-10 pr-4 py-2 text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all duration-300 backdrop-blur-sm"
               />
             </div>
@@ -103,14 +105,14 @@ export function Header() {
                 className="text-foreground/80 hover:text-primary transition-colors duration-300 px-4 py-2 rounded-lg hover:bg-card/50"
                 onClick={handleMobileMenuClose}
               >
-                Boutiques
+                {t("header.shops")}
               </Link>
               <Link
                 to="/search?type=services"
                 className="text-foreground/80 hover:text-primary transition-colors duration-300 px-4 py-2 rounded-lg hover:bg-card/50"
                 onClick={handleMobileMenuClose}
               >
-                Artisans
+                {t("header.artisans")}
               </Link>
             </nav>
           </div>

--- a/src/components/Layout/UserMenu.tsx
+++ b/src/components/Layout/UserMenu.tsx
@@ -14,9 +14,11 @@ import {
 import { useAuth } from "../../contexts/AuthContext";
 import { useCart } from "../../contexts/CartContext";
 import { NotificationsBell } from "../Notifications";
+import { useTranslation } from "react-i18next";
 import supabase from "../../lib/supabase";
 
 export function UserMenu() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [hasShop, setHasShop] = useState(false);
@@ -100,16 +102,16 @@ export function UserMenu() {
   };
 
   const getDashboardLabel = () => {
-    if (!profile) return "Dashboard";
+    if (!profile) return t("userMenu.dashboard");
 
     switch (profile.role) {
       case "admin":
-        return "Admin Panel";
+        return t("userMenu.adminPanel");
       case "creator":
-        return hasShop ? "Creator Studio" : "Studio Créateur";
+        return t("userMenu.creatorStudio");
       case "buyer":
       default:
-        return "Mes Commandes";
+        return t("userMenu.orders");
     }
   };
 
@@ -145,7 +147,7 @@ export function UserMenu() {
           className="flex items-center space-x-2 text-muted-foreground hover:text-primary transition-colors duration-300 px-3 sm:px-4 py-2 text-sm font-light rounded-xl hover:bg-card/50"
         >
           <LogIn className="h-4 w-4 sm:h-5 sm:w-5" />
-          <span className="hidden sm:inline">Se connecter</span>
+          <span className="hidden sm:inline">{t("userMenu.signIn")}</span>
         </Link>
         <Link
           to="/auth/signup"
@@ -153,7 +155,7 @@ export function UserMenu() {
         >
           <span className="block px-4 sm:px-6 py-2 text-sm font-medium text-foreground hover:text-primary transition-colors duration-300 flex items-center space-x-2">
             <UserPlus className="h-4 w-4 sm:h-5 sm:w-5" />
-            <span className="hidden sm:inline">S'inscrire</span>
+            <span className="hidden sm:inline">{t("userMenu.signUp")}</span>
           </span>
         </Link>
       </div>
@@ -188,7 +190,7 @@ export function UserMenu() {
         >
           <User className="h-5 w-5" />
           <span className="hidden xl:inline text-sm font-light">
-            {profile?.display_name || "Compte"}
+            {profile?.display_name || t("userMenu.account")}
           </span>
         </button>
 
@@ -203,7 +205,7 @@ export function UserMenu() {
                   onClick={() => setIsDropdownOpen(false)}
                 >
                   <Shield className="w-4 h-4 mr-3 text-primary" />
-                  Admin Panel
+                  {t("userMenu.adminPanel")}
                 </Link>
               )}
 
@@ -225,7 +227,7 @@ export function UserMenu() {
                       onClick={() => setIsDropdownOpen(false)}
                     >
                       <Package className="w-4 h-4 mr-3 text-primary" />
-                      Gérer la Boutique
+                      {t("userMenu.manageShop")}
                     </Link>
                   )}
                 </>
@@ -238,7 +240,7 @@ export function UserMenu() {
                 onClick={() => setIsDropdownOpen(false)}
               >
                 <Package className="w-4 h-4 mr-3 text-primary" />
-                Mes Commandes
+                {t("userMenu.orders")}
               </Link>
 
               <hr className="border-border/30 my-2" />
@@ -248,7 +250,7 @@ export function UserMenu() {
                 onClick={() => setIsDropdownOpen(false)}
               >
                 <User className="w-4 h-4 mr-3" />
-                Paramètres du Profil
+                {t("userMenu.profile")}
               </Link>
               <hr className="border-border/30 my-2" />
               <button
@@ -256,7 +258,7 @@ export function UserMenu() {
                 className="block w-full text-left px-4 py-3 text-sm text-popover-foreground hover:bg-primary/10 hover:text-primary transition-colors duration-200"
               >
                 <LogOut className="w-4 h-4 mr-3 inline" />
-                Se déconnecter
+                {t("userMenu.signOut")}
               </button>
             </div>
           </div>

--- a/src/components/Notifications/NotificationPanel.tsx
+++ b/src/components/Notifications/NotificationPanel.tsx
@@ -5,6 +5,7 @@ import { fr } from "date-fns/locale";
 import { ExternalLink, Bell, Settings, CheckCheck } from "lucide-react";
 import { useNotifications } from "../../hooks/useNotifications";
 import { Notification } from "../../types/notifications";
+import { useTranslation } from "react-i18next";
 
 const getCategoryIcon = (category: string) => {
   switch (category) {
@@ -132,16 +133,21 @@ export function NotificationPanel() {
     markAllAsRead,
     isMarkingAllAsRead,
   } = useNotifications();
+  const { t } = useTranslation();
 
   if (isLoading) {
     return (
       <div className="w-80 sm:w-96 bg-card border border-border rounded-lg shadow-xl">
         <div className="p-4 border-b border-border/30">
-          <h3 className="font-medium text-foreground">Notifications</h3>
+          <h3 className="font-medium text-foreground">
+            {t("notificationPanel.title")}
+          </h3>
         </div>
         <div className="p-8 text-center">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
-          <p className="text-sm text-muted-foreground mt-2">Chargement...</p>
+          <p className="text-sm text-muted-foreground mt-2">
+            {t("notificationPanel.loading")}
+          </p>
         </div>
       </div>
     );
@@ -153,7 +159,7 @@ export function NotificationPanel() {
       <div className="p-4 border-b border-border/30 bg-card/50">
         <div className="flex items-center justify-between">
           <h3 className="font-medium text-foreground">
-            Notifications
+            {t("notificationPanel.title")}
             {unreadCount > 0 && (
               <span className="ml-2 text-xs bg-primary text-primary-foreground px-2 py-1 rounded-full">
                 {unreadCount}
@@ -166,24 +172,26 @@ export function NotificationPanel() {
                 onClick={() => {
                   console.log(
                     '🔄 Bouton "Tout lire" cliqué, unreadCount:',
-                    unreadCount
+                    unreadCount,
                   );
                   markAllAsRead();
                 }}
                 disabled={isMarkingAllAsRead}
                 className="text-xs text-primary hover:text-primary/80 flex items-center space-x-1"
-                title="Tout marquer comme lu"
+                title={t("notificationPanel.markAllTitle")}
               >
                 <CheckCheck className="w-3 h-3" />
                 <span>
-                  {isMarkingAllAsRead ? "Chargement..." : "Tout lire"}
+                  {isMarkingAllAsRead
+                    ? t("notificationPanel.loading")
+                    : t("notificationPanel.markAll")}
                 </span>
               </button>
             )}
             <Link
               to="/notifications/preferences"
               className="text-muted-foreground hover:text-foreground"
-              title="Paramètres de notifications"
+              title={t("notificationPanel.settings")}
             >
               <Settings className="w-4 h-4" />
             </Link>
@@ -197,7 +205,7 @@ export function NotificationPanel() {
           <div className="p-8 text-center">
             <Bell className="w-12 h-12 text-muted-foreground mx-auto mb-3" />
             <p className="text-sm text-muted-foreground">
-              Aucune notification pour le moment
+              {t("notificationPanel.empty")}
             </p>
           </div>
         ) : (
@@ -218,7 +226,7 @@ export function NotificationPanel() {
       {notifications.length > 0 && (
         <div className="p-3 border-t border-border/30 bg-card/50">
           <button className="w-full text-xs text-center text-primary hover:text-primary/80">
-            Voir toutes les notifications
+            {t("notificationPanel.viewAll")}
           </button>
         </div>
       )}

--- a/src/components/UI/ImageUpload.tsx
+++ b/src/components/UI/ImageUpload.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef } from "react";
 import { Upload, X, Image as ImageIcon } from "lucide-react";
 import { Button } from "./Button";
 import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
 
 interface ImageUploadProps {
   label?: string;
@@ -20,6 +21,7 @@ export function ImageUpload({
 }: ImageUploadProps) {
   const [uploading, setUploading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { t } = useTranslation();
 
   const handleFileSelect = async (
     event: React.ChangeEvent<HTMLInputElement>
@@ -30,7 +32,9 @@ export function ImageUpload({
     const remainingSlots = maxImages - images.length;
     if (files.length > remainingSlots) {
       toast.error(
-        `Vous ne pouvez ajouter que ${remainingSlots} image(s) supplémentaire(s)`
+        t("imageUpload.limit", {
+          count: remainingSlots,
+        })
       );
       return;
     }
@@ -44,13 +48,17 @@ export function ImageUpload({
 
         // Validation du type de fichier
         if (!file.type.startsWith("image/")) {
-          toast.error(`${file.name} n'est pas une image valide`);
+          toast.error(
+            t("imageUpload.invalidType", { file: file.name })
+          );
           continue;
         }
 
         // Validation de la taille (max 5MB)
         if (file.size > 5 * 1024 * 1024) {
-          toast.error(`${file.name} est trop volumineux (max 5MB)`);
+          toast.error(
+            t("imageUpload.tooLarge", { file: file.name })
+          );
           continue;
         }
 
@@ -68,7 +76,11 @@ export function ImageUpload({
       }
 
       onImagesChange([...images, ...newImageUrls]);
-      toast.success(`${newImageUrls.length} image(s) ajoutée(s)`);
+      toast.success(
+        t("imageUpload.uploadSuccess", {
+          count: newImageUrls.length,
+        })
+      );
 
       // Reset file input
       if (fileInputRef.current) {
@@ -76,7 +88,7 @@ export function ImageUpload({
       }
     } catch (error) {
       console.error("Erreur lors de l'upload:", error);
-      toast.error("Erreur lors de l'upload des images");
+      toast.error(t("imageUpload.uploadError"));
     } finally {
       setUploading(false);
     }

--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "./AuthContext";
 import analyticsService from "../services/analytics";
 import { StockNotificationService } from "../services/stockNotificationService";
 import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
 
 export interface CartItem {
   id: string;
@@ -80,6 +81,7 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
     loading: false,
   });
   const { user, authStable } = useAuth();
+  const { t } = useTranslation();
 
   useEffect(() => {
     // Attendre que l'auth soit stable avant de récupérer le panier
@@ -126,9 +128,9 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
         unit_price: item.unit_price,
         currency: item.currency,
         metadata: item.metadata,
-        title: item.metadata?.title || "Article inconnu",
+        title: item.metadata?.title || t("cart.unknownItem"),
         image_url: item.metadata?.image_url || "",
-        shop_name: item.metadata?.shop_name || "Boutique inconnue",
+        shop_name: item.metadata?.shop_name || t("cart.unknownShop"),
         shop_id: item.metadata?.shop_id || "",
       }));
 
@@ -142,9 +144,7 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
 
   const addToCart = async (item: Omit<CartItem, "id">) => {
     if (!user) {
-      toast.error(
-        "Veuillez vous connecter pour ajouter des articles au panier"
-      );
+      toast.error(t("cart.mustSignIn"));
       return;
     }
 
@@ -158,13 +158,15 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
 
         if (!stockInfo.available) {
           toast.error(
-            `Stock insuffisant. Seulement ${stockInfo.availableStock} article(s) disponible(s)`
+            t("cart.stockInsufficient", {
+              stock: stockInfo.availableStock,
+            })
           );
           return;
         }
       } catch (error) {
         console.error("Erreur lors de la vérification du stock:", error);
-        toast.error("Impossible de vérifier le stock");
+        toast.error(t("cart.stockCheckError"));
         return;
       }
     }
@@ -209,10 +211,10 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
         StockNotificationService.checkStockAfterCartAction(item.item_id);
       }
 
-      toast.success("Ajouté au panier");
+      toast.success(t("cart.addSuccess"));
     } catch (error) {
       console.error("Erreur lors de l'ajout au panier:", error);
-      toast.error("Impossible d'ajouter au panier");
+      toast.error(t("cart.addError"));
     }
   };
 
@@ -233,7 +235,7 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
       dispatch({ type: "UPDATE_ITEM", payload: { id: itemId, qty } });
     } catch (error) {
       console.error("Error updating quantity:", error);
-      toast.error("Failed to update quantity");
+      toast.error(t("cart.updateError"));
     }
   };
 
@@ -256,10 +258,10 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
         analyticsService.trackCartRemoval(itemToRemove.item_id, user?.id);
       }
 
-      toast.success("Supprimé du panier");
+      toast.success(t("cart.removeSuccess"));
     } catch (error) {
       console.error("Erreur lors de la suppression:", error);
-      toast.error("Impossible de supprimer du panier");
+      toast.error(t("cart.removeError"));
     }
   };
 
@@ -277,7 +279,7 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
       dispatch({ type: "CLEAR_CART" });
     } catch (error) {
       console.error("Error clearing cart:", error);
-      toast.error("Failed to clear cart");
+      toast.error(t("cart.clearError"));
     }
   };
 

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -4,11 +4,13 @@ import { NotificationService } from "../services/notificationService";
 import { Notification } from "../types/notifications";
 import { useAuth } from "../contexts/AuthContext";
 import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
 
 export function useNotifications() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);
+  const { t } = useTranslation();
 
   // Récupérer les notifications
   const {
@@ -160,10 +162,10 @@ export function useNotifications() {
         );
       }
       console.error("Erreur lors du marquage de toutes comme lues:", err);
-      toast.error("Erreur lors du marquage des notifications");
+      toast.error(t("notifications.markError"));
     },
     onSuccess: () => {
-      toast.success("Toutes les notifications ont été marquées comme lues");
+      toast.success(t("notifications.markSuccess"));
     },
     onSettled: () => {
       // Refetch pour s'assurer que les données sont à jour

--- a/src/hooks/useStockMonitoring.ts
+++ b/src/hooks/useStockMonitoring.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { StockInfo } from "../types";
 import analyticsService from "../services/analytics";
+import { useTranslation } from "react-i18next";
 
 /**
  * Hook pour surveiller le stock d'un produit en temps réel
@@ -9,6 +10,7 @@ export function useStockMonitoring(productId: string, enabled: boolean = true) {
   const [stockInfo, setStockInfo] = useState<StockInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { t } = useTranslation();
 
   const checkStock = async (quantity: number = 1) => {
     if (!productId || !enabled) return;
@@ -24,9 +26,7 @@ export function useStockMonitoring(productId: string, enabled: boolean = true) {
       setStockInfo(stock);
     } catch (err) {
       setError(
-        err instanceof Error
-          ? err.message
-          : "Erreur lors de la vérification du stock"
+        err instanceof Error ? err.message : t("stock.checkError")
       );
     } finally {
       setLoading(false);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,20 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './locales/en/translation.json';
+import fr from './locales/fr/translation.json';
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      fr: { translation: fr },
+    },
+    lng: 'fr',
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false,
+    },
+  });
+
+export default i18n;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,0 +1,579 @@
+{
+  "checkoutSummary": {
+    "title": "Order Summary",
+    "completeShipping": "Please complete the shipping address to continue.",
+    "noImage": "No Image"
+  },
+  "artistCard": {
+    "bannerAlt": "Banner of {{shopName}}",
+    "verified": "Verified",
+    "products": "{{count}} product",
+    "products_plural": "{{count}} products",
+    "services": "{{count}} service",
+    "services_plural": "{{count}} services"
+  },
+  "common": {
+    "noCategory": "No category",
+    "status": {
+      "active": "Active",
+      "draft": "Draft",
+      "paused": "Paused",
+      "sold_out": "Sold out"
+    },
+    "types": {
+      "physical": "Physical",
+      "digital": "Digital"
+    },
+    "price": "Price",
+    "stockTotal": "Total stock",
+    "available": "Available",
+    "unlimited": "Unlimited",
+    "views": "Views",
+    "sales": "Sales",
+    "revenue": "Revenue",
+    "edit": "Edit",
+    "view": "View",
+    "delete": "Delete",
+    "inCarts": "{{count}} in cart",
+    "inCarts_plural": "{{count}} in carts",
+    "days": "{{count}} day",
+    "days_plural": "{{count}} days",
+    "briefRequired": "Brief required",
+    "startingFrom": "Starting from",
+    "orders": "Orders",
+    "item": "Item",
+    "new": "New",
+    "orderStatus": {
+      "paid": "Paid",
+      "processing": "Processing",
+      "completed": "Completed",
+      "shipped": "Shipped"
+    }
+  },
+  "productsTable": {
+    "loadError": "Unable to load products",
+    "deleteSuccess": "Product deleted successfully",
+    "deleteError": "Unable to delete product",
+    "confirmDelete": "Are you sure you want to delete the product \"{{title}}\"? This action is irreversible.",
+    "heading": "My Products",
+    "headingCount": "My Products ({{count}})",
+    "create": "Create product",
+    "emptyTitle": "No product created",
+    "emptyDescription": "Create your first product to start selling your creations",
+    "emptyAction": "Create my first product"
+  },
+  "servicesTable": {
+    "loadError": "Unable to load services",
+    "deleteSuccess": "Service deleted successfully",
+    "deleteError": "Unable to delete service",
+    "confirmDelete": "Are you sure you want to delete the service \"{{title}}\"? This action is irreversible.",
+    "heading": "My Services",
+    "headingCount": "My Services ({{count}})",
+    "create": "Create service",
+    "emptyTitle": "No service created",
+    "emptyDescription": "Create your first service to offer your skills and services",
+    "emptyAction": "Create my first service",
+    "editComingSoon": "Service editing page coming soon"
+  },
+  "home": {
+    "featuredCategories": {
+      "cardAlters": {
+        "description": "Transform your favorite cards into unique works of art"
+      },
+      "customTokens": { "description": "Professional game tokens and pieces" },
+      "deckbuilding": {
+        "description": "Improve your gameplay with expert advice"
+      },
+      "playmats": {
+        "description": "Custom playmats, deck boxes, and accessories"
+      }
+    },
+    "hero": {
+      "tagline": "The Premier Magic Crafting Hub",
+      "title": { "part1": "Magic", "part2": "Art", "part3": "Shops" },
+      "description": "Discover unique card alters, tokens, and creations from talented artists worldwide",
+      "explore": "Explore Shops",
+      "becomeCreator": "Become a Creator",
+      "stats": {
+        "artists": "Active Artists",
+        "countries": "Countries",
+        "satisfaction": "Satisfaction"
+      }
+    },
+    "categories": {
+      "title": "Popular Categories",
+      "subtitle": "Discover the most requested creations by our customers",
+      "popular": "Popular"
+    },
+    "artists": {
+      "title": "Popular Artists",
+      "subtitle": "Discover our most talented artists and their unique creations"
+    },
+    "features": {
+      "title": "Why Choose ManaShop?",
+      "subtitle": "The trusted art shops for your magical creations",
+      "verified": {
+        "title": "Verified Artists",
+        "description": "All artists are verified professionals ensuring quality work for your cards."
+      },
+      "network": {
+        "title": "Global Network",
+        "description": "Connect with talented artists worldwide, each bringing unique skills and expertise."
+      },
+      "secure": {
+        "title": "Secure Transactions",
+        "description": "Secure payments with buyer protection and satisfaction guarantees."
+      }
+    },
+    "cta": {
+      "title": "Ready to Find Your Perfect Artist?",
+      "subtitle": "Join thousands of players who have discovered incredible magical artworks",
+      "explore": "Discover Shops"
+    }
+  },
+  "search": {
+    "resultsFor": "Results for \"{{query}}\"",
+    "browse": "Browse Shops",
+    "loading": "Searching...",
+    "resultsCount": "{{count}} result found",
+    "resultsCount_plural": "{{count}} results found",
+    "view": {
+      "grid": "Grid",
+      "categories": "Categories"
+    },
+    "filters": {
+      "show": "Show filters",
+      "hide": "Hide filters",
+      "title": "Filters",
+      "clear": "Clear all",
+      "type": {
+        "label": "Type",
+        "all": "All items",
+        "product": "Products",
+        "service": "Services"
+      },
+      "category": {
+        "label": "Category",
+        "all": "All categories"
+      },
+      "price": {
+        "label": "Price range",
+        "min": "Min",
+        "max": "Max"
+      },
+      "sort": {
+        "label": "Sort by",
+        "newest": "Newest",
+        "priceAsc": "Price: Low to High",
+        "priceDesc": "Price: High to Low"
+      }
+    },
+    "noResults": "No items found matching your criteria.",
+    "categoryCount": "{{count}} item",
+    "categoryCount_plural": "{{count}} items"
+  },
+  "checkout": {
+    "addressSaved": "Address saved to your profile",
+    "addressError": "Error saving address",
+    "orderSuccess": "Order placed successfully!",
+    "orderError": "Error creating order",
+    "empty": {
+      "title": "Your cart is empty",
+      "subtitle": "Add items to your cart before proceeding to checkout",
+      "action": "Browse shops"
+    },
+    "backToCart": "Back to cart",
+    "title": "Complete Checkout",
+    "shipping": {
+      "title": "Shipping Address",
+      "subtitle": "Where would you like to receive your order?",
+      "name": "Full name",
+      "namePlaceholder": "Your full name",
+      "phone": "Phone",
+      "phonePlaceholder": "Your phone number",
+      "address": "Address",
+      "addressPlaceholder": "Full address",
+      "city": "City",
+      "postalCode": "Postal Code",
+      "country": "Country",
+      "save": "Save to my profile"
+    },
+    "payment": {
+      "title": "Payment Method",
+      "securedBy": "Secured by PayPal"
+    }
+  },
+  "auth": {
+    "signUp": {
+      "success": "Account created successfully!",
+      "error": "Failed to create account",
+      "hero": {
+        "title": "Join our community",
+        "subtitle": "Create an account to start buying or selling"
+      },
+      "emailLabel": "Email address",
+      "emailPlaceholder": "you@example.com",
+      "displayNameLabel": "Display name",
+      "displayNamePlaceholder": "Your name",
+      "passwordLabel": "Password",
+      "passwordPlaceholder": "Create a strong password",
+      "choosePath": "Choose your path:",
+      "paths": {
+        "buyer": {
+          "title": "Collector",
+          "description": "Order legendary art"
+        },
+        "creator": {
+          "title": "Artist",
+          "description": "Create magical services"
+        }
+      },
+      "submit": "Create account",
+      "haveAccount": "Already have an account?",
+      "signIn": "Sign in"
+    },
+    "signIn": {
+      "success": "Welcome!",
+      "invalidCredentials": "Invalid email or password. Please check your credentials.",
+      "error": "Failed to sign in",
+      "heroTitle": "Welcome back, Planeswalker",
+      "heroSubtitle": "Enter your guild credentials to access the multiverse",
+      "emailLabel": "Email address",
+      "emailPlaceholder": "you@example.com",
+      "passwordLabel": "Password",
+      "passwordPlaceholder": "Enter your password",
+      "submit": "Sign in",
+      "showTest": "Show test accounts",
+      "hideTest": "Hide test accounts",
+      "testAccounts": "Test accounts:",
+      "noAccount": "Don't have an account?",
+      "signUp": "Sign up"
+    }
+  },
+  "cart": {
+    "title": "Shopping Cart",
+    "empty": {
+      "title": "Your Cart is Empty",
+      "description": "Discover amazing artworks and professional services from talented creators",
+      "cta": "Start Shopping"
+    },
+    "itemCount": "{{count}} item",
+    "itemCount_plural": "{{count}} items",
+    "unitPrice": "${{price}} each",
+    "noImage": "No image",
+    "remove": "Remove",
+    "summary": {
+      "title": "Order Summary",
+      "total": "Total"
+    },
+    "checkout": "Proceed to Checkout",
+    "continue": "Continue Shopping",
+    "total": "Total: ${{total}}"
+  },
+  "footer": {
+    "description": "The reference art shops for custom Magic: The Gathering art, alters, tokens and unique creations. Discover talented artists from around the world.",
+    "sections": {
+      "shops": {
+        "title": "Shops",
+        "cardAlters": "Card Alters",
+        "customTokens": "Custom Tokens",
+        "playmats": "Playmats",
+        "deckbuilding": "Deckbuilding Artists"
+      },
+      "support": {
+        "title": "Support",
+        "helpCenter": "Help Center",
+        "sellerGuide": "Seller Guide",
+        "terms": "Terms of Service",
+        "privacy": "Privacy Policy"
+      }
+    },
+    "rights": "All rights reserved.",
+    "trademark": "Magic: The Gathering is a trademark of Wizards of the Coast.",
+    "madeWith": "Made with",
+    "byFans": "by fans"
+  },
+  "userMenu": {
+    "signIn": "Sign in",
+    "signUp": "Sign up",
+    "dashboard": "Dashboard",
+    "adminPanel": "Admin Panel",
+    "creatorStudio": "Creator Studio",
+    "manageShop": "Manage Shop",
+    "orders": "My Orders",
+    "profile": "Profile Settings",
+    "signOut": "Sign out",
+    "account": "Account"
+  },
+  "header": {
+    "shops": "Shops",
+    "artisans": "Creators",
+    "searchPlaceholder": "Search creations..."
+  },
+  "serviceCard": {
+    "requiresBrief": "Consultation required",
+    "quickOrder": "Quick order",
+    "requiresBriefShort": "Consult",
+    "quickOrderShort": "Quick"
+  },
+  "stockAlerts": {
+    "title": "Stock Alerts ({{count}})",
+    "outOfStock": "Out of stock",
+    "remaining": "Only {{count}} left",
+    "remaining_plural": "Only {{count}} left",
+    "inCarts": "({{count}} in cart)",
+    "inCarts_plural": "({{count}} in carts)",
+    "manage": "Manage"
+  },
+  "profile": {
+    "updateSuccess": "Profile updated successfully!",
+    "updateError": "Failed to update profile",
+    "title": "Profile Settings",
+    "subtitle": "Manage your personal information and preferences",
+    "anonymous": "Anonymous",
+    "roles": {
+      "creator": "creator",
+      "admin": "administrator",
+      "buyer": "buyer"
+    },
+    "delivery": {
+      "title": "Shipping Address",
+      "name": "Full Name",
+      "namePlaceholder": "John Doe",
+      "address": "Address",
+      "addressPlaceholder": "123 Main St, Apt 4B",
+      "city": "City",
+      "cityPlaceholder": "Paris",
+      "postalCode": "Postal Code",
+      "postalCodePlaceholder": "75001",
+      "country": "Country",
+      "selectCountry": "Select a country"
+    },
+    "countries": {
+      "france": "France",
+      "unitedStates": "United States",
+      "canada": "Canada",
+      "unitedKingdom": "United Kingdom",
+      "germany": "Germany",
+      "japan": "Japan",
+      "australia": "Australia"
+    },
+    "personal": {
+      "title": "Personal Information",
+      "displayName": "Display Name",
+      "displayNamePlaceholder": "Your display name",
+      "bio": "Biography",
+      "bioPlaceholder": "Tell us about yourself..."
+    },
+    "saving": "Saving...",
+    "save": "Save to profile"
+  },
+  "creatorDashboard": {
+    "welcome": {
+      "title": "Welcome to your Creator Studio",
+      "subtitle": "Set up your shop to start selling your amazing art and services",
+      "createShop": "Create your shop"
+    },
+    "header": {
+      "title": "Creator Studio",
+      "subtitle": "{{shopName}} • Manage your creations"
+    },
+    "actions": {
+      "addProduct": "Add a product",
+      "addService": "Add a service"
+    },
+    "stats": {
+      "products": "Products",
+      "services": "Services",
+      "orders": "Orders",
+      "revenue": "Revenue",
+      "inCarts": "including {{count}} in cart",
+      "inCarts_plural": "including {{count}} in carts"
+    },
+    "recent": {
+      "title": "Recent Activity",
+      "viewAll": "View all orders",
+      "emptyTitle": "No recent orders",
+      "emptySubtitle": "New orders will appear here",
+      "order": "Order #{{id}}",
+      "qty": "Qty: {{count}}"
+    }
+  },
+  "buyerDashboard": {
+    "title": "Dashboard",
+    "subtitle": "Track your orders and manage your purchases",
+    "stats": {
+      "total": "Total orders",
+      "completed": "Completed orders",
+      "inProgress": "In progress",
+      "pending": "Pending"
+    },
+    "tabs": {
+      "all": "All"
+    },
+    "empty": {
+      "title": "No orders found",
+      "all": "You haven't placed any orders yet.",
+      "status": "No orders with status \"{{status}}\"."
+    },
+    "order": {
+      "title": "Order #{{id}}",
+      "from": "From {{shopName}} • Qty: {{qty}}",
+      "contactSeller": "Contact seller",
+      "leaveReview": "Leave a review",
+      "tracking": "Tracking:",
+      "delivery": "Estimated delivery:"
+    }
+  },
+  "adminDashboard": {
+    "title": "Admin Panel",
+    "subtitle": "Manage ManaShop stores",
+    "totalUsers": "Total Users",
+    "creators": "Creators",
+    "productsServices": "Products & Services",
+    "totalRevenue": "Total Revenue",
+    "recentOrders": "Recent Orders",
+    "viewAll": "View all",
+    "noRecentOrders": "No recent orders",
+    "order": "Order #{{id}}",
+    "itemCount": "{{count}} item",
+    "itemCount_plural": "{{count}} items",
+    "quickActions": "Quick Actions",
+    "manageUsers": "Manage Users",
+    "manageUsersDesc": "View and edit user profiles",
+    "moderateContent": "Moderate Content",
+    "moderateContentDesc": "Review and approve products",
+    "reports": "Reports",
+    "reportsDesc": "Analyze performance"
+  },
+  "cart": {
+    "mustSignIn": "Please sign in to add items to the cart",
+    "stockInsufficient": "Insufficient stock. Only {{stock}} item(s) available",
+    "stockCheckError": "Unable to check stock",
+    "addSuccess": "Added to cart",
+    "addError": "Unable to add to cart",
+    "updateError": "Failed to update quantity",
+    "removeSuccess": "Removed from cart",
+    "removeError": "Unable to remove from cart",
+    "clearError": "Failed to clear cart",
+    "unknownItem": "Unknown item",
+    "unknownShop": "Unknown shop"
+  },
+  "notifications": {
+    "markError": "Error marking notifications",
+    "markSuccess": "All notifications marked as read"
+  },
+  "stock": {
+    "checkError": "Error checking stock"
+  },
+  "createProduct": {
+    "needShop": "Please create your shop first",
+    "success": "Product created successfully!",
+    "error": "Failed to create product"
+  },
+  "editProduct": {
+    "needShop": "Please create your shop first",
+    "notFound": "Product not found",
+    "unauthorized": "Unauthorized access",
+    "loadError": "Error loading product",
+    "success": "Product updated successfully!",
+    "error": "Failed to update product"
+  },
+  "productDetail": {
+    "notFound": "Product not found",
+    "addSuccess": "Product added to cart!",
+    "addError": "Failed to add to cart"
+  },
+  "notificationPreferences": {
+    "saveSuccess": "Preferences saved successfully",
+    "saveError": "Error saving preferences"
+  },
+  "imageUpload": {
+    "limit": "You can only add {{count}} more image",
+    "limit_plural": "You can only add {{count}} more images",
+    "invalidType": "{{file}} is not a valid image",
+    "tooLarge": "{{file}} is too large (max 5MB)",
+    "uploadSuccess": "{{count}} image added",
+    "uploadSuccess_plural": "{{count}} images added",
+    "uploadError": "Error uploading images"
+  },
+  "stockInfoCard": {
+    "title": "How does stock management work?",
+    "totalTitle": "Total Inventory Stock",
+    "totalDesc": "This is the total number of items you have in stock. You can modify it in the product edit page.",
+    "inCartsTitle": "Items in Carts",
+    "inCartsDesc": "Number of items currently in customers' carts (but not yet purchased).",
+    "calcTitle": "📊 Available Stock Calculation",
+    "total": "Total stock:",
+    "inCarts": "In carts:",
+    "available": "Available:",
+    "items": "{{count}} item",
+    "items_plural": "{{count}} items",
+    "tip": "💡 Tip: Available stock is displayed in real time to customers. If a customer adds an item to their cart, the available stock decreases immediately for others."
+  },
+  "shippingManager": {
+    "title": "Shipping Fees",
+    "newProfile": "New profile",
+    "newProfileTitle": "New shipping profile",
+    "nameLabel": "Profile name *",
+    "namePlaceholder": "e.g. Standard Shipping",
+    "baseCostLabel": "Base cost (€)",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "Optional description",
+    "freeShippingLabel": "Free shipping from (€)",
+    "freeShippingPlaceholder": "Optional",
+    "defaultLabel": "Set as default profile",
+    "cancel": "Cancel",
+    "create": "Create profile",
+    "noProfiles": "No shipping profile configured",
+    "createFirst": "Create your first profile to set your shipping fees",
+    "defaultTag": "Default",
+    "baseCost": "Base cost:",
+    "freeFrom": "Free from:",
+    "setDefault": "Set default",
+    "errors": {
+      "load": "Unable to load shipping settings",
+      "nameRequired": "Profile name is required",
+      "create": "Failed to create profile",
+      "delete": "Failed to delete profile",
+      "update": "Failed to update profile"
+    },
+    "success": {
+      "create": "Shipping profile created",
+      "delete": "Profile deleted",
+      "updateDefault": "Default profile updated"
+    },
+    "confirmDelete": "Delete profile \"{{name}}\"?",
+    "howItWorks": {
+      "title": "How it works?",
+      "default": "• The default profile will apply to all new orders",
+      "calc": "• Shipping fees are calculated automatically at checkout",
+      "free": "• Free shipping applies if the amount exceeds the defined threshold",
+      "multiple": "• You can create multiple profiles for different product types"
+    }
+  },
+  "notificationPanel": {
+    "title": "Notifications",
+    "loading": "Loading...",
+    "markAllTitle": "Mark all as read",
+    "markAll": "Mark all",
+    "settings": "Notification settings",
+    "empty": "No notifications yet",
+    "viewAll": "View all notifications"
+  },
+  "creatorProfile": {
+    "notFound": "Shop not found",
+    "bannerAlt": "Banner of {{shopName}}",
+    "verified": "Verified",
+    "new": "New",
+    "memberSince": "Member since {{year}}",
+    "tabs": {
+      "products": "Products ({{count}})",
+      "services": "Services ({{count}})"
+    },
+    "productsEmptyTitle": "No products available",
+    "productsEmptySubtitle": "This shop has no products yet",
+    "servicesEmptyTitle": "No services available",
+    "servicesEmptySubtitle": "This shop has no services yet"
+  }
+}

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1,0 +1,581 @@
+{
+  "checkoutSummary": {
+    "title": "Résumé de la commande",
+    "completeShipping": "Veuillez compléter l'adresse de livraison pour continuer.",
+    "noImage": "Pas d'image"
+  },
+  "artistCard": {
+    "bannerAlt": "Bannière de {{shopName}}",
+    "verified": "Vérifié",
+    "products": "{{count}} produit",
+    "products_plural": "{{count}} produits",
+    "services": "{{count}} service",
+    "services_plural": "{{count}} services"
+  },
+  "common": {
+    "noCategory": "Sans catégorie",
+    "status": {
+      "active": "Actif",
+      "draft": "Brouillon",
+      "paused": "En pause",
+      "sold_out": "Épuisé"
+    },
+    "types": {
+      "physical": "Physique",
+      "digital": "Numérique"
+    },
+    "price": "Prix",
+    "stockTotal": "Stock total",
+    "available": "Disponible",
+    "unlimited": "Illimité",
+    "views": "Vues",
+    "sales": "Ventes",
+    "revenue": "Revenus",
+    "edit": "Éditer",
+    "view": "Voir",
+    "delete": "Supprimer",
+    "inCarts": "{{count}} en panier",
+    "inCarts_plural": "{{count}} en paniers",
+    "days": "{{count}} jour",
+    "days_plural": "{{count}} jours",
+    "briefRequired": "Brief requis",
+    "startingFrom": "À partir de",
+    "orders": "Commandes",
+    "item": "Article",
+    "new": "Nouveau",
+    "orderStatus": {
+      "paid": "Payé",
+      "processing": "En traitement",
+      "completed": "Terminé",
+      "shipped": "Expédié"
+    }
+  },
+  "productsTable": {
+    "loadError": "Impossible de charger les produits",
+    "deleteSuccess": "Produit supprimé avec succès",
+    "deleteError": "Impossible de supprimer le produit",
+    "confirmDelete": "Êtes-vous sûr de vouloir supprimer le produit \"{{title}}\" ? Cette action est irréversible.",
+    "heading": "Mes Produits",
+    "headingCount": "Mes Produits ({{count}})",
+    "create": "Créer un produit",
+    "emptyTitle": "Aucun produit créé",
+    "emptyDescription": "Créez votre premier produit pour commencer à vendre vos créations",
+    "emptyAction": "Créer mon premier produit"
+  },
+  "servicesTable": {
+    "loadError": "Impossible de charger les services",
+    "deleteSuccess": "Service supprimé avec succès",
+    "deleteError": "Impossible de supprimer le service",
+    "confirmDelete": "Êtes-vous sûr de vouloir supprimer le service \"{{title}}\" ? Cette action est irréversible.",
+    "heading": "Mes Services",
+    "headingCount": "Mes Services ({{count}})",
+    "create": "Créer un service",
+    "emptyTitle": "Aucun service créé",
+    "emptyDescription": "Créez votre premier service pour proposer vos compétences et services",
+    "emptyAction": "Créer mon premier service",
+    "editComingSoon": "Page d'édition de service à venir"
+  },
+  "home": {
+    "featuredCategories": {
+      "cardAlters": {
+        "description": "Transformez vos cartes préférées en œuvres d'art uniques"
+      },
+      "customTokens": {
+        "description": "Jetons et pièces de jeu professionnels"
+      },
+      "deckbuilding": {
+        "description": "Améliorez votre gameplay avec des conseils d'experts"
+      },
+      "playmats": {
+        "description": "Tapis de jeu, boîtes de deck et accessoires personnalisés"
+      }
+    },
+    "hero": {
+      "tagline": "L'Artisanat Magique de Référence",
+      "title": { "part1": "Boutiques", "part2": "d'Art", "part3": "Magique" },
+      "description": "Découvrez des alters de cartes uniques, des jetons et des créations magiques d'artistes talentueux du monde entier",
+      "explore": "Explorer les Boutiques",
+      "becomeCreator": "Devenir Créateur",
+      "stats": {
+        "artists": "Artistes Actifs",
+        "countries": "Pays",
+        "satisfaction": "Satisfaction"
+      }
+    },
+    "categories": {
+      "title": "Catégories Populaires",
+      "subtitle": "Découvrez les créations les plus demandées par nos clients",
+      "popular": "Populaire"
+    },
+    "artists": {
+      "title": "Artistes Populaires",
+      "subtitle": "Découvrez nos artistes les plus talentueux et leurs créations uniques"
+    },
+    "features": {
+      "title": "Pourquoi Choisir ManaShop ?",
+      "subtitle": "Les boutiques d'art de confiance pour vos créations magiques de qualité",
+      "verified": {
+        "title": "Artistes Vérifiés",
+        "description": "Tous les artistes sont des professionnels vérifiés garantissant un travail de qualité pour vos cartes."
+      },
+      "network": {
+        "title": "Réseau Mondial",
+        "description": "Connectez-vous avec des artistes talentueux du monde entier, chacun apportant des compétences et une expertise uniques."
+      },
+      "secure": {
+        "title": "Transactions Sécurisées",
+        "description": "Paiements sécurisés avec protection de l'acheteur et garanties de satisfaction."
+      }
+    },
+    "cta": {
+      "title": "Prêt à Trouver Votre Artiste Parfait ?",
+      "subtitle": "Rejoignez des milliers de joueurs qui ont découvert des œuvres d'art magiques incroyables",
+      "explore": "Découvrir les Boutiques"
+    }
+  },
+  "search": {
+    "resultsFor": "Résultats pour \"{{query}}\"",
+    "browse": "Parcourir les Boutiques",
+    "loading": "Recherche en cours...",
+    "resultsCount": "{{count}} résultat trouvé",
+    "resultsCount_plural": "{{count}} résultats trouvés",
+    "view": {
+      "grid": "Grille",
+      "categories": "Catégories"
+    },
+    "filters": {
+      "show": "Afficher les filtres",
+      "hide": "Masquer les filtres",
+      "title": "Filtres",
+      "clear": "Effacer tout",
+      "type": {
+        "label": "Type",
+        "all": "Tous les éléments",
+        "product": "Produits",
+        "service": "Artisans"
+      },
+      "category": {
+        "label": "Catégorie",
+        "all": "Toutes les catégories"
+      },
+      "price": {
+        "label": "Fourchette de prix",
+        "min": "Min",
+        "max": "Max"
+      },
+      "sort": {
+        "label": "Trier par",
+        "newest": "Plus récent",
+        "priceAsc": "Prix : Croissant",
+        "priceDesc": "Prix : Décroissant"
+      }
+    },
+    "noResults": "Aucun élément trouvé correspondant à vos critères.",
+    "categoryCount": "{{count}} élément",
+    "categoryCount_plural": "{{count}} éléments"
+  },
+  "checkout": {
+    "addressSaved": "Adresse sauvegardée dans votre profil",
+    "addressError": "Erreur lors de la sauvegarde de l'adresse",
+    "orderSuccess": "Commande passée avec succès !",
+    "orderError": "Erreur lors de la création de la commande",
+    "empty": {
+      "title": "Votre panier est vide",
+      "subtitle": "Ajoutez des articles à votre panier avant de procéder au paiement",
+      "action": "Parcourir les boutiques"
+    },
+    "backToCart": "Retour au panier",
+    "title": "Finaliser la commande",
+    "shipping": {
+      "title": "Adresse de livraison",
+      "subtitle": "Où souhaitez-vous recevoir votre commande ?",
+      "name": "Nom complet",
+      "namePlaceholder": "Votre nom complet",
+      "phone": "Téléphone",
+      "phonePlaceholder": "Votre numéro de téléphone",
+      "address": "Adresse",
+      "addressPlaceholder": "Adresse complète",
+      "city": "Ville",
+      "postalCode": "Code postal",
+      "country": "Pays",
+      "save": "Sauvegarder dans mon profil"
+    },
+    "payment": {
+      "title": "Méthode de paiement",
+      "securedBy": "Sécurisé par PayPal"
+    }
+  },
+  "auth": {
+    "signUp": {
+      "success": "Compte créé avec succès !",
+      "error": "Échec de la création du compte",
+      "hero": {
+        "title": "Rejoignez notre communauté",
+        "subtitle": "Créez un compte pour commencer à acheter ou vendre"
+      },
+      "emailLabel": "Adresse email",
+      "emailPlaceholder": "vous@exemple.com",
+      "displayNameLabel": "Nom d'affichage",
+      "displayNamePlaceholder": "Votre nom",
+      "passwordLabel": "Mot de passe",
+      "passwordPlaceholder": "Créez un mot de passe fort",
+      "choosePath": "Choisissez votre voie :",
+      "paths": {
+        "buyer": {
+          "title": "Collectionneur",
+          "description": "Commandez de l'art légendaire"
+        },
+        "creator": {
+          "title": "Artisan",
+          "description": "Créez des services magiques"
+        }
+      },
+      "submit": "Créer le compte",
+      "haveAccount": "Vous avez déjà un compte ?",
+      "signIn": "Se connecter"
+    },
+    "signIn": {
+      "success": "Bienvenue !",
+      "invalidCredentials": "Email ou mot de passe invalide. Veuillez vérifier vos identifiants.",
+      "error": "Échec de la connexion",
+      "heroTitle": "Bon retour, Planeswalker",
+      "heroSubtitle": "Entrez vos identifiants de guilde pour accéder au multivers",
+      "emailLabel": "Adresse email",
+      "emailPlaceholder": "vous@exemple.com",
+      "passwordLabel": "Mot de passe",
+      "passwordPlaceholder": "Entrez votre mot de passe",
+      "submit": "Se connecter",
+      "showTest": "Afficher les comptes de test",
+      "hideTest": "Masquer les comptes de test",
+      "testAccounts": "Comptes de test :",
+      "noAccount": "Vous n'avez pas de compte ?",
+      "signUp": "S'inscrire"
+    }
+  },
+  "cart": {
+    "title": "Panier d'Achats",
+    "empty": {
+      "title": "Votre Panier est Vide",
+      "description": "Découvrez des œuvres d'art incroyables et des services professionnels de créateurs talentueux",
+      "cta": "Commencer les Achats"
+    },
+    "itemCount": "{{count}} article",
+    "itemCount_plural": "{{count}} articles",
+    "unitPrice": "${{price}} l'unité",
+    "noImage": "Pas d'image",
+    "remove": "Supprimer",
+    "summary": {
+      "title": "Résumé de la Commande",
+      "total": "Total"
+    },
+    "checkout": "Passer la Commande",
+    "continue": "Continuer les Achats",
+    "total": "Total : ${{total}}"
+  },
+  "footer": {
+    "description": "Les boutiques d'art de référence pour l'art personnalisé Magic: The Gathering, les alters, tokens et créations uniques. Découvrez des artistes talentueux du monde entier.",
+    "sections": {
+      "shops": {
+        "title": "Boutiques",
+        "cardAlters": "Alters de cartes",
+        "customTokens": "Jetons personnalisés",
+        "playmats": "Playmats",
+        "deckbuilding": "Artisans de Deckbuilding"
+      },
+      "support": {
+        "title": "Support",
+        "helpCenter": "Centre d'aide",
+        "sellerGuide": "Guide du vendeur",
+        "terms": "Conditions d'utilisation",
+        "privacy": "Politique de confidentialité"
+      }
+    },
+    "rights": "Tous droits réservés.",
+    "trademark": "Magic: The Gathering est une marque déposée de Wizards of the Coast.",
+    "madeWith": "Fait avec",
+    "byFans": "par des passionnés"
+  },
+  "userMenu": {
+    "signIn": "Se connecter",
+    "signUp": "S'inscrire",
+    "dashboard": "Tableau de bord",
+    "adminPanel": "Admin Panel",
+    "creatorStudio": "Studio Créateur",
+    "manageShop": "Gérer la Boutique",
+    "orders": "Mes Commandes",
+    "profile": "Paramètres du Profil",
+    "signOut": "Se déconnecter",
+    "account": "Compte"
+  },
+  "header": {
+    "shops": "Boutiques",
+    "artisans": "Artisans",
+    "searchPlaceholder": "Rechercher des créations..."
+  },
+  "serviceCard": {
+    "requiresBrief": "Consultation requise",
+    "quickOrder": "Commande rapide",
+    "requiresBriefShort": "Consult",
+    "quickOrderShort": "Rapide"
+  },
+  "stockAlerts": {
+    "title": "Alertes Stock ({{count}})",
+    "outOfStock": "Rupture de stock",
+    "remaining": "Plus que {{count}} disponible",
+    "remaining_plural": "Plus que {{count}} disponibles",
+    "inCarts": "({{count}} en panier)",
+    "inCarts_plural": "({{count}} en paniers)",
+    "manage": "Gérer"
+  },
+  "profile": {
+    "updateSuccess": "Profil mis à jour avec succès !",
+    "updateError": "Échec de la mise à jour du profil",
+    "title": "Paramètres du Profil",
+    "subtitle": "Gérez vos informations personnelles et vos préférences",
+    "anonymous": "Anonyme",
+    "roles": {
+      "creator": "créateur",
+      "admin": "administrateur",
+      "buyer": "acheteur"
+    },
+    "delivery": {
+      "title": "Adresse de livraison",
+      "name": "Nom complet",
+      "namePlaceholder": "Jean Dupont",
+      "address": "Adresse",
+      "addressPlaceholder": "123 Rue Principale, Appt 4B",
+      "city": "Ville",
+      "cityPlaceholder": "Paris",
+      "postalCode": "Code postal",
+      "postalCodePlaceholder": "75001",
+      "country": "Pays",
+      "selectCountry": "Sélectionner un pays"
+    },
+    "countries": {
+      "france": "France",
+      "unitedStates": "États-Unis",
+      "canada": "Canada",
+      "unitedKingdom": "Royaume-Uni",
+      "germany": "Allemagne",
+      "japan": "Japon",
+      "australia": "Australie"
+    },
+    "personal": {
+      "title": "Informations personnelles",
+      "displayName": "Nom d'affichage",
+      "displayNamePlaceholder": "Votre nom d'affichage",
+      "bio": "Biographie",
+      "bioPlaceholder": "Parlez-nous de vous..."
+    },
+    "saving": "Sauvegarde...",
+    "save": "Sauvegarder dans mon profil"
+  },
+  "creatorDashboard": {
+    "welcome": {
+      "title": "Bienvenue dans votre Studio Créateur",
+      "subtitle": "Configurez votre boutique pour commencer à vendre vos œuvres d'art et services incroyables",
+      "createShop": "Créer votre boutique"
+    },
+    "header": {
+      "title": "Studio Créateur",
+      "subtitle": "{{shopName}} • Gérez vos créations"
+    },
+    "actions": {
+      "addProduct": "Ajouter un produit",
+      "addService": "Ajouter un service"
+    },
+    "stats": {
+      "products": "Produits",
+      "services": "Services",
+      "orders": "Commandes",
+      "revenue": "Revenus",
+      "inCarts": "dont {{count}} en panier",
+      "inCarts_plural": "dont {{count}} en paniers"
+    },
+    "recent": {
+      "title": "Activité Récente",
+      "viewAll": "Voir toutes les commandes",
+      "emptyTitle": "Aucune commande récente",
+      "emptySubtitle": "Les nouvelles commandes apparaîtront ici",
+      "order": "Commande #{{id}}",
+      "qty": "Qté: {{count}}"
+    }
+  },
+  "buyerDashboard": {
+    "title": "Tableau de Bord",
+    "subtitle": "Suivez vos commandes et gérez vos achats",
+    "stats": {
+      "total": "Total des commandes",
+      "completed": "Commandes terminées",
+      "inProgress": "En cours",
+      "pending": "En attente"
+    },
+    "tabs": {
+      "all": "Toutes"
+    },
+    "empty": {
+      "title": "Aucune commande trouvée",
+      "all": "Vous n'avez pas encore passé de commande.",
+      "status": "Aucune commande avec le statut \"{{status}}\"."
+    },
+  "order": {
+    "title": "Commande #{{id}}",
+    "from": "De {{shopName}} • Qté: {{qty}}",
+    "contactSeller": "Contacter le vendeur",
+    "leaveReview": "Laisser un avis",
+    "tracking": "Suivi :",
+    "delivery": "Livraison prévue :"
+  }
+  },
+  "adminDashboard": {
+    "title": "Panneau d'administration",
+    "subtitle": "Gestion des boutiques ManaShop",
+    "totalUsers": "Utilisateurs totaux",
+    "creators": "Créateurs",
+    "productsServices": "Produits & Services",
+    "totalRevenue": "Revenus totaux",
+    "recentOrders": "Commandes Récentes",
+    "viewAll": "Voir toutes",
+    "noRecentOrders": "Aucune commande récente",
+    "order": "Commande #{{id}}",
+    "itemCount": "{{count}} article",
+    "itemCount_plural": "{{count}} articles",
+    "quickActions": "Actions Rapides",
+    "manageUsers": "Gérer les Utilisateurs",
+    "manageUsersDesc": "Voir et modifier les profils utilisateurs",
+    "moderateContent": "Modérer le Contenu",
+    "moderateContentDesc": "Examiner et approuver les produits",
+    "reports": "Rapports",
+    "reportsDesc": "Analyser les performances"
+  },
+  "cart": {
+    "mustSignIn": "Veuillez vous connecter pour ajouter des articles au panier",
+    "stockInsufficient": "Stock insuffisant. Seulement {{stock}} article(s) disponible(s)",
+    "stockCheckError": "Impossible de vérifier le stock",
+    "addSuccess": "Ajouté au panier",
+    "addError": "Impossible d'ajouter au panier",
+    "updateError": "Impossible de mettre à jour la quantité",
+    "removeSuccess": "Supprimé du panier",
+    "removeError": "Impossible de supprimer du panier",
+    "clearError": "Impossible de vider le panier",
+    "unknownItem": "Article inconnu",
+    "unknownShop": "Boutique inconnue"
+  },
+  "notifications": {
+    "markError": "Erreur lors du marquage des notifications",
+    "markSuccess": "Toutes les notifications ont été marquées comme lues"
+  },
+  "stock": {
+    "checkError": "Erreur lors de la vérification du stock"
+  },
+  "createProduct": {
+    "needShop": "Veuillez créer votre boutique d'abord",
+    "success": "Produit créé avec succès !",
+    "error": "Échec de la création du produit"
+  },
+  "editProduct": {
+    "needShop": "Veuillez créer votre boutique d'abord",
+    "notFound": "Produit non trouvé",
+    "unauthorized": "Accès non autorisé",
+    "loadError": "Erreur lors du chargement du produit",
+    "success": "Produit mis à jour avec succès !",
+    "error": "Échec de la mise à jour du produit"
+  },
+  "productDetail": {
+    "notFound": "Produit non trouvé",
+    "addSuccess": "Produit ajouté au panier !",
+    "addError": "Échec de l'ajout au panier"
+  },
+  "notificationPreferences": {
+    "saveSuccess": "Préférences sauvegardées avec succès",
+    "saveError": "Erreur lors de la sauvegarde des préférences"
+  },
+  "imageUpload": {
+    "limit": "Vous ne pouvez ajouter que {{count}} image supplémentaire",
+    "limit_plural": "Vous ne pouvez ajouter que {{count}} images supplémentaires",
+    "invalidType": "{{file}} n'est pas une image valide",
+    "tooLarge": "{{file}} est trop volumineux (max 5MB)",
+    "uploadSuccess": "{{count}} image ajoutée",
+    "uploadSuccess_plural": "{{count}} images ajoutées",
+    "uploadError": "Erreur lors de l'upload des images"
+  },
+  "stockInfoCard": {
+    "title": "Comment fonctionne la gestion du stock ?",
+    "totalTitle": "Stock Total en Inventaire",
+    "totalDesc": "C'est le nombre total d'articles que vous avez en stock. Vous pouvez le modifier dans l'édition du produit.",
+    "inCartsTitle": "Articles en Paniers",
+    "inCartsDesc": "Nombre d'articles actuellement dans les paniers des clients (mais pas encore achetés).",
+    "calcTitle": "📊 Calcul du Stock Disponible",
+    "total": "Stock total :",
+    "inCarts": "En paniers :",
+    "available": "Disponible :",
+    "items": "{{count}} article",
+    "items_plural": "{{count}} articles",
+    "tip": "💡 Conseil : Le stock disponible est affiché en temps réel aux clients. Si un client ajoute un article à son panier, le stock disponible diminue immédiatement pour les autres clients."
+  },
+  "shippingManager": {
+    "title": "Frais de Livraison",
+    "newProfile": "Nouveau profil",
+    "newProfileTitle": "Nouveau profil de livraison",
+    "nameLabel": "Nom du profil *",
+    "namePlaceholder": "ex: Livraison Standard",
+    "baseCostLabel": "Coût de base (€)",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "Description optionnelle",
+    "freeShippingLabel": "Livraison gratuite à partir de (€)",
+    "freeShippingPlaceholder": "Optionnel",
+    "defaultLabel": "Définir comme profil par défaut",
+    "cancel": "Annuler",
+    "create": "Créer le profil",
+    "noProfiles": "Aucun profil de livraison configuré",
+    "createFirst": "Créez votre premier profil pour définir vos frais de livraison",
+    "defaultTag": "Par défaut",
+    "baseCost": "Coût de base :",
+    "freeFrom": "Gratuit à partir de :",
+    "setDefault": "Définir par défaut",
+    "errors": {
+      "load": "Impossible de charger les paramètres de livraison",
+      "nameRequired": "Le nom du profil est requis",
+      "create": "Impossible de créer le profil",
+      "delete": "Impossible de supprimer le profil",
+      "update": "Impossible de mettre à jour le profil"
+    },
+    "success": {
+      "create": "Profil de livraison créé",
+      "delete": "Profil supprimé",
+      "updateDefault": "Profil par défaut mis à jour"
+    },
+    "confirmDelete": "Supprimer le profil \"{{name}}\" ?",
+    "howItWorks": {
+      "title": "Comment ça marche ?",
+      "default": "• Le profil par défaut sera appliqué à toutes les nouvelles commandes",
+      "calc": "• Les frais de livraison sont calculés automatiquement lors du checkout",
+      "free": "• La livraison gratuite s'applique si le montant dépasse le seuil défini",
+      "multiple": "• Vous pouvez créer plusieurs profils pour différents types de produits"
+    }
+  },
+  "notificationPanel": {
+    "title": "Notifications",
+    "loading": "Chargement...",
+    "markAllTitle": "Tout marquer comme lu",
+    "markAll": "Tout lire",
+    "settings": "Paramètres de notifications",
+    "empty": "Aucune notification pour le moment",
+    "viewAll": "Voir toutes les notifications"
+  },
+  "creatorProfile": {
+    "notFound": "Boutique introuvable",
+    "bannerAlt": "Bannière de {{shopName}}",
+    "verified": "Vérifié",
+    "new": "Nouveau",
+    "memberSince": "Membre depuis {{year}}",
+    "tabs": {
+      "products": "Produits ({{count}})",
+      "services": "Services ({{count}})"
+    },
+    "productsEmptyTitle": "Aucun produit disponible",
+    "productsEmptySubtitle": "Cette boutique n'a pas encore de produits",
+    "servicesEmptyTitle": "Aucun service disponible",
+    "servicesEmptySubtitle": "Cette boutique n'a pas encore de services"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import './i18n';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/Admin/AdminDashboard.tsx
+++ b/src/pages/Admin/AdminDashboard.tsx
@@ -6,14 +6,15 @@ import {
   Briefcase,
   DollarSign,
   TrendingUp,
-  AlertCircle,
   Shield,
 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { LoadingSpinner } from "../../components/UI/LoadingSpinner";
 import { Card, CardHeader, CardContent } from "../../components/UI/Card";
 import { Button } from "../../components/UI/Button";
 
 export function AdminDashboard() {
+  const { t, i18n } = useTranslation();
   const [stats, setStats] = useState({
     totalUsers: 0,
     totalCreators: 0,
@@ -85,10 +86,10 @@ export function AdminDashboard() {
           </div>
           <div>
             <h1 className="text-4xl md:text-5xl font-light text-foreground tracking-tight">
-              Admin Panel
+              {t("adminDashboard.title")}
             </h1>
             <p className="text-muted-foreground/70 text-lg">
-              Gestion des boutiques ManaShop
+              {t("adminDashboard.subtitle")}
             </p>
           </div>
         </div>
@@ -104,7 +105,7 @@ export function AdminDashboard() {
             {stats.totalUsers.toLocaleString()}
           </div>
           <div className="text-muted-foreground/70 text-sm">
-            Utilisateurs totaux
+            {t("adminDashboard.totalUsers")}
           </div>
         </Card>
 
@@ -115,7 +116,9 @@ export function AdminDashboard() {
           <div className="text-3xl font-light text-foreground mb-2">
             {stats.totalCreators.toLocaleString()}
           </div>
-          <div className="text-muted-foreground/70 text-sm">Créateurs</div>
+          <div className="text-muted-foreground/70 text-sm">
+            {t("adminDashboard.creators")}
+          </div>
         </Card>
 
         <Card className="text-center p-6">
@@ -126,7 +129,7 @@ export function AdminDashboard() {
             {(stats.totalProducts + stats.totalServices).toLocaleString()}
           </div>
           <div className="text-muted-foreground/70 text-sm">
-            Produits & Services
+            {t("adminDashboard.productsServices")}
           </div>
         </Card>
 
@@ -137,7 +140,9 @@ export function AdminDashboard() {
           <div className="text-3xl font-light text-foreground mb-2">
             ${stats.totalRevenue.toLocaleString()}
           </div>
-          <div className="text-muted-foreground/70 text-sm">Revenus totaux</div>
+          <div className="text-muted-foreground/70 text-sm">
+            {t("adminDashboard.totalRevenue")}
+          </div>
         </Card>
       </div>
 
@@ -145,10 +150,10 @@ export function AdminDashboard() {
       <div className="mb-12">
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-2xl font-light text-foreground tracking-tight">
-            Commandes Récentes
+            {t("adminDashboard.recentOrders")}
           </h2>
           <Button variant="outline" size="sm">
-            Voir toutes
+            {t("adminDashboard.viewAll")}
           </Button>
         </div>
 
@@ -157,7 +162,7 @@ export function AdminDashboard() {
             <Card className="text-center p-12">
               <Package className="h-16 w-16 text-muted-foreground/40 mx-auto mb-4" />
               <p className="text-muted-foreground/70">
-                Aucune commande récente
+                {t("adminDashboard.noRecentOrders")}
               </p>
             </Card>
           ) : (
@@ -166,20 +171,24 @@ export function AdminDashboard() {
                 <div className="flex items-center justify-between">
                   <div>
                     <h3 className="text-lg font-light text-foreground">
-                      Commande #{order.id.slice(-8)}
+                      {t("adminDashboard.order", { id: order.id.slice(-8) })}
                     </h3>
                     <p className="text-muted-foreground/70 text-sm">
-                      {new Date(order.created_at).toLocaleDateString("fr-FR", {
-                        year: "numeric",
-                        month: "long",
-                        day: "numeric",
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      })}
+                      {new Date(order.created_at).toLocaleDateString(
+                        i18n.language === "fr" ? "fr-FR" : "en-US",
+                        {
+                          year: "numeric",
+                          month: "long",
+                          day: "numeric",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        }
+                      )}
                     </p>
                     <p className="text-muted-foreground/70 text-sm">
-                      {order.order_items?.length || 0} article
-                      {order.order_items?.length > 1 ? "s" : ""}
+                      {t("adminDashboard.itemCount", {
+                        count: order.order_items?.length || 0,
+                      })}
                     </p>
                   </div>
                   <div className="text-right">
@@ -200,7 +209,7 @@ export function AdminDashboard() {
       {/* Quick Actions */}
       <div>
         <h2 className="text-2xl font-light text-foreground tracking-tight mb-6">
-          Actions Rapides
+          {t("adminDashboard.quickActions")}
         </h2>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -209,10 +218,10 @@ export function AdminDashboard() {
               <Users className="h-8 w-8 text-primary" />
             </div>
             <h3 className="text-lg font-light text-foreground mb-2">
-              Gérer les Utilisateurs
+              {t("adminDashboard.manageUsers")}
             </h3>
             <p className="text-muted-foreground/70 text-sm">
-              Voir et modifier les profils utilisateurs
+              {t("adminDashboard.manageUsersDesc")}
             </p>
           </Card>
 
@@ -221,10 +230,10 @@ export function AdminDashboard() {
               <Package className="h-8 w-8 text-primary" />
             </div>
             <h3 className="text-lg font-light text-foreground mb-2">
-              Modérer le Contenu
+              {t("adminDashboard.moderateContent")}
             </h3>
             <p className="text-muted-foreground/70 text-sm">
-              Examiner et approuver les produits
+              {t("adminDashboard.moderateContentDesc")}
             </p>
           </Card>
 
@@ -233,10 +242,10 @@ export function AdminDashboard() {
               <TrendingUp className="h-8 w-8 text-primary" />
             </div>
             <h3 className="text-lg font-light text-foreground mb-2">
-              Rapports
+              {t("adminDashboard.reports")}
             </h3>
             <p className="text-muted-foreground/70 text-sm">
-              Analyser les performances
+              {t("adminDashboard.reportsDesc")}
             </p>
           </Card>
         </div>

--- a/src/pages/Auth/SignIn.tsx
+++ b/src/pages/Auth/SignIn.tsx
@@ -5,6 +5,7 @@ import { Eye, EyeOff, Sparkles } from "lucide-react";
 import toast from "react-hot-toast";
 import { Button } from "../../components/UI/Button";
 import { Input } from "../../components/UI/Input";
+import { useTranslation } from "react-i18next";
 
 export function SignIn() {
   const [email, setEmail] = useState("");
@@ -14,6 +15,7 @@ export function SignIn() {
   const [showTestAccounts, setShowTestAccounts] = useState(false);
   const { signIn } = useAuth();
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   const testAccounts = [
     { email: "admin@manashop.com", password: "admin123!", role: "Admin" },
@@ -30,15 +32,13 @@ export function SignIn() {
       const { error } = await signIn(email, password);
       if (error) throw error;
 
-      toast.success("Bienvenue !");
+      toast.success(t("auth.signIn.success"));
       navigate("/");
     } catch (error: any) {
       if (error.message?.includes("Invalid login credentials")) {
-        toast.error(
-          "Email ou mot de passe invalide. Veuillez vérifier vos identifiants."
-        );
+        toast.error(t("auth.signIn.invalidCredentials"));
       } else {
-        toast.error(error.message || "Échec de la connexion");
+        toast.error(error.message || t("auth.signIn.error"));
       }
     } finally {
       setLoading(false);
@@ -77,21 +77,21 @@ export function SignIn() {
             </span>
           </Link>
           <h2 className="text-3xl md:text-4xl font-light text-foreground tracking-tight mb-3">
-            Bon retour, Planeswalker
+            {t("auth.signIn.heroTitle")}
           </h2>
           <p className="text-muted-foreground/80 text-lg">
-            Entrez vos identifiants de guilde pour accéder au multivers
+            {t("auth.signIn.heroSubtitle")}
           </p>
         </div>
 
         <form className="space-y-6 md:space-y-8" onSubmit={handleSubmit}>
           <Input
-            label="Adresse email"
+            label={t("auth.signIn.emailLabel")}
             type="email"
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            placeholder="vous@exemple.com"
+            placeholder={t("auth.signIn.emailPlaceholder")}
             id="email"
           />
 
@@ -100,7 +100,7 @@ export function SignIn() {
               htmlFor="password"
               className="block text-sm font-medium text-foreground mb-3"
             >
-              Mot de passe
+              {t("auth.signIn.passwordLabel")}
             </label>
             <div className="relative">
               <Input
@@ -108,7 +108,7 @@ export function SignIn() {
                 required
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                placeholder="Entrez votre mot de passe"
+                placeholder={t("auth.signIn.passwordPlaceholder")}
                 id="password"
                 className="pr-12"
               />
@@ -133,7 +133,7 @@ export function SignIn() {
             loading={loading}
             className="w-full"
           >
-            Se connecter
+            {t("auth.signIn.submit")}
           </Button>
 
           <div className="text-center">
@@ -144,13 +144,17 @@ export function SignIn() {
               onClick={() => setShowTestAccounts(!showTestAccounts)}
               className="text-muted-foreground/70 hover:text-primary"
             >
-              {showTestAccounts ? "Masquer" : "Afficher"} les comptes de test
+              {showTestAccounts
+                ? t("auth.signIn.hideTest")
+                : t("auth.signIn.showTest")}
             </Button>
           </div>
 
           {showTestAccounts && (
             <div className="glass rounded-3xl p-6 space-y-3 border border-border/30">
-              <p className="text-sm text-foreground mb-4">Comptes de test :</p>
+              <p className="text-sm text-foreground mb-4">
+                {t("auth.signIn.testAccounts")}
+              </p>
               {testAccounts.map((account, index) => (
                 <button
                   key={index}
@@ -173,12 +177,12 @@ export function SignIn() {
 
           <div className="text-center">
             <p className="text-muted-foreground/70">
-              Vous n'avez pas de compte ?{" "}
+              {t("auth.signIn.noAccount")} {" "}
               <Link
                 to="/auth/signup"
                 className="text-primary hover:text-primary/80 font-medium transition-colors duration-300"
               >
-                S'inscrire
+                {t("auth.signIn.signUp")}
               </Link>
             </p>
           </div>

--- a/src/pages/Auth/SignUp.tsx
+++ b/src/pages/Auth/SignUp.tsx
@@ -5,6 +5,7 @@ import { Eye, EyeOff, Sparkles, Palette, Package } from "lucide-react";
 import toast from "react-hot-toast";
 import { Button } from "../../components/UI/Button";
 import { Input } from "../../components/UI/Input";
+import { useTranslation } from "react-i18next";
 
 export function SignUp() {
   const [email, setEmail] = useState("");
@@ -15,6 +16,7 @@ export function SignUp() {
   const [loading, setLoading] = useState(false);
   const { signUp } = useAuth();
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -24,10 +26,10 @@ export function SignUp() {
       const { error } = await signUp(email, password, displayName);
       if (error) throw error;
 
-      toast.success("Compte créé avec succès !");
+      toast.success(t("auth.signUp.success"));
       navigate("/");
     } catch (error: any) {
-      toast.error(error.message || "Échec de la création du compte");
+      toast.error(error.message || t("auth.signUp.error"));
     } finally {
       setLoading(false);
     }
@@ -60,30 +62,30 @@ export function SignUp() {
             </span>
           </Link>
           <h2 className="text-3xl md:text-4xl font-light text-foreground tracking-tight mb-3">
-            Rejoignez notre communauté
+            {t("auth.signUp.hero.title")}
           </h2>
           <p className="text-muted-foreground/80 text-lg">
-            Créez un compte pour commencer à acheter ou vendre
+            {t("auth.signUp.hero.subtitle")}
           </p>
         </div>
 
         <form className="space-y-6 md:space-y-8" onSubmit={handleSubmit}>
           <Input
-            label="Adresse email"
+            label={t("auth.signUp.emailLabel")}
             type="email"
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            placeholder="vous@exemple.com"
+            placeholder={t("auth.signUp.emailPlaceholder")}
             id="email"
           />
 
           <Input
-            label="Nom d'affichage"
+            label={t("auth.signUp.displayNameLabel")}
             type="text"
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
-            placeholder="Votre nom"
+            placeholder={t("auth.signUp.displayNamePlaceholder")}
             id="displayName"
           />
 
@@ -92,7 +94,7 @@ export function SignUp() {
               htmlFor="password"
               className="block text-sm font-medium text-foreground mb-3"
             >
-              Mot de passe
+              {t("auth.signUp.passwordLabel")}
             </label>
             <div className="relative">
               <Input
@@ -100,7 +102,7 @@ export function SignUp() {
                 required
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                placeholder="Créez un mot de passe fort"
+                placeholder={t("auth.signUp.passwordPlaceholder")}
                 id="password"
                 className="pr-12"
               />
@@ -120,7 +122,7 @@ export function SignUp() {
 
           <div>
             <label className="block text-sm font-medium text-foreground mb-4">
-              Choisissez votre voie :
+              {t("auth.signUp.choosePath")}
             </label>
             <div className="grid grid-cols-2 gap-4">
               <label
@@ -141,10 +143,10 @@ export function SignUp() {
                 <div className="text-center">
                   <Package className="h-8 w-8 text-primary mx-auto mb-3" />
                   <div className="text-lg font-medium text-foreground">
-                    Collectionneur
+                    {t("auth.signUp.paths.buyer.title")}
                   </div>
                   <div className="text-sm text-muted-foreground/70">
-                    Commandez de l'art légendaire
+                    {t("auth.signUp.paths.buyer.description")}
                   </div>
                 </div>
               </label>
@@ -167,10 +169,10 @@ export function SignUp() {
                 <div className="text-center">
                   <Palette className="h-8 w-8 text-primary mx-auto mb-3" />
                   <div className="text-lg font-medium text-foreground">
-                    Artisan
+                    {t("auth.signUp.paths.creator.title")}
                   </div>
                   <div className="text-sm text-muted-foreground/70">
-                    Créez des services magiques
+                    {t("auth.signUp.paths.creator.description")}
                   </div>
                 </div>
               </label>
@@ -184,17 +186,17 @@ export function SignUp() {
             loading={loading}
             className="w-full"
           >
-            Créer le compte
+            {t("auth.signUp.submit")}
           </Button>
 
           <div className="text-center">
             <p className="text-muted-foreground/70">
-              Vous avez déjà un compte ?{" "}
+              {t("auth.signUp.haveAccount")} {" "}
               <Link
                 to="/auth/signin"
                 className="text-primary hover:text-primary/80 font-medium transition-colors duration-300"
               >
-                Se connecter
+                {t("auth.signUp.signIn")}
               </Link>
             </p>
           </div>

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -5,6 +5,7 @@ import { useCart } from "../contexts/CartContext";
 import { LoadingSpinner } from "../components/UI/LoadingSpinner";
 import { Button } from "../components/UI/Button";
 import { Card, CardHeader, CardContent } from "../components/UI/Card";
+import { useTranslation } from "react-i18next";
 
 export function Cart() {
   const {
@@ -15,6 +16,7 @@ export function Cart() {
     getTotal,
     getItemCount,
   } = useCart();
+  const { t } = useTranslation();
 
   if (loading) {
     return (
@@ -32,15 +34,14 @@ export function Cart() {
             <ShoppingCart className="h-12 w-12 text-primary" />
           </div>
           <h1 className="text-4xl font-light text-foreground tracking-tight mb-4">
-            Votre Panier est Vide
+            {t("cart.empty.title")}
           </h1>
           <p className="text-muted-foreground/70 text-lg mb-8">
-            Découvrez des œuvres d'art incroyables et des services
-            professionnels de créateurs talentueux
+            {t("cart.empty.description")}
           </p>
           <Link to="/search">
             <Button variant="gradient" size="lg" icon={ArrowRight}>
-              Commencer les Achats
+              {t("cart.empty.cta")}
             </Button>
           </Link>
         </div>
@@ -66,11 +67,10 @@ export function Cart() {
     <div className="max-w-7xl mx-auto px-6 lg:px-8 py-12">
       <div className="mb-8">
         <h1 className="text-4xl font-light text-foreground tracking-tight mb-2">
-          Panier d'Achats
+          {t("cart.title")}
         </h1>
         <p className="text-muted-foreground/70 text-lg">
-          {getItemCount()} article{getItemCount() > 1 ? "s" : ""} • Total: $
-          {getTotal().toFixed(2)}
+          {t("cart.itemCount", { count: getItemCount() })} • {t("cart.total", { total: getTotal().toFixed(2) })}
         </p>
       </div>
 
@@ -101,7 +101,7 @@ export function Cart() {
                           />
                         ) : (
                           <div className="w-full h-full flex items-center justify-center text-muted-foreground/60 text-xs">
-                            Pas d'image
+                            {t("cart.noImage")}
                           </div>
                         )}
                       </div>
@@ -112,7 +112,7 @@ export function Cart() {
                           {item.title}
                         </h4>
                         <p className="text-muted-foreground/70 text-sm mb-2">
-                          ${item.unit_price} l'unité
+                          {t("cart.unitPrice", { price: item.unit_price })}
                         </p>
 
                         {/* Quantity Controls */}
@@ -153,7 +153,7 @@ export function Cart() {
                           onClick={() => removeFromCart(item.id)}
                           className="text-destructive/80 hover:text-destructive hover:bg-destructive/10"
                         >
-                          Supprimer
+                          {t("cart.remove")}
                         </Button>
                       </div>
                     </div>
@@ -169,7 +169,7 @@ export function Cart() {
           <Card className="sticky top-24">
             <CardHeader>
               <h2 className="text-2xl font-light text-foreground tracking-tight">
-                Résumé de la Commande
+                {t("cart.summary.title")}
               </h2>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -191,7 +191,7 @@ export function Cart() {
               <hr className="border-border/30" />
 
               <div className="flex justify-between text-lg font-medium">
-                <span className="text-foreground">Total</span>
+                <span className="text-foreground">{t("cart.summary.total")}</span>
                 <span className="text-primary">${getTotal().toFixed(2)}</span>
               </div>
 
@@ -202,13 +202,13 @@ export function Cart() {
                   icon={ArrowRight}
                   className="w-full"
                 >
-                  Passer la Commande
+                  {t("cart.checkout")}
                 </Button>
               </Link>
 
               <Link to="/search" className="block w-full">
                 <Button variant="outline" size="md" className="w-full">
-                  Continuer les Achats
+                  {t("cart.continue")}
                 </Button>
               </Link>
             </CardContent>

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -12,11 +12,13 @@ import toast from "react-hot-toast";
 import { Button } from "../components/UI/Button";
 import { Input } from "../components/UI/Input";
 import { Card, CardHeader, CardContent } from "../components/UI/Card";
+import { useTranslation } from "react-i18next";
 
 export function Checkout() {
   const { items, getTotal, clearCart } = useCart();
   const { profile, updateProfile } = useAuth();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const [processing, setProcessing] = useState(false);
   const [savingAddress, setSavingAddress] = useState(false);
   const [shippingAddress, setShippingAddress] = useState({
@@ -60,9 +62,9 @@ export function Checkout() {
       });
 
       if (error) throw error;
-      toast.success("Adresse sauvegardée dans votre profil");
+      toast.success(t("checkout.addressSaved"));
     } catch (error) {
-      toast.error("Erreur lors de la sauvegarde de l'adresse");
+      toast.error(t("checkout.addressError"));
     } finally {
       setSavingAddress(false);
     }
@@ -153,11 +155,11 @@ export function Checkout() {
 
       // Clear cart and redirect
       clearCart();
-      toast.success("Commande passée avec succès !");
+      toast.success(t("checkout.orderSuccess"));
       navigate(`/dashboard/buyer`);
     } catch (error) {
       console.error("Error creating order:", error);
-      toast.error("Erreur lors de la création de la commande");
+      toast.error(t("checkout.orderError"));
     } finally {
       setProcessing(false);
     }
@@ -169,17 +171,17 @@ export function Checkout() {
         <Card className="text-center p-16">
           <CreditCard className="h-16 w-16 text-muted-foreground/40 mx-auto mb-6" />
           <h1 className="text-2xl font-light text-foreground mb-4">
-            Votre panier est vide
+            {t("checkout.empty.title")}
           </h1>
           <p className="text-muted-foreground/70 mb-6">
-            Ajoutez des articles à votre panier avant de procéder au paiement
+            {t("checkout.empty.subtitle")}
           </p>
           <Button
             variant="primary"
             size="lg"
             onClick={() => navigate("/search")}
           >
-            Parcourir les boutiques
+            {t("checkout.empty.action")}
           </Button>
         </Card>
       </div>
@@ -195,10 +197,10 @@ export function Checkout() {
           className="inline-flex items-center text-muted-foreground/70 hover:text-primary transition-colors duration-300 mb-4"
         >
           <ArrowLeft className="h-4 w-4 mr-2" />
-          Retour au panier
+          {t("checkout.backToCart")}
         </Link>
         <h1 className="text-4xl font-light text-foreground tracking-tight">
-          Finaliser la commande
+          {t("checkout.title")}
         </h1>
       </div>
 
@@ -215,10 +217,10 @@ export function Checkout() {
                   </div>
                   <div>
                     <h2 className="text-xl font-light text-foreground">
-                      Adresse de livraison
+                      {t("checkout.shipping.title")}
                     </h2>
                     <p className="text-muted-foreground/70">
-                      Où souhaitez-vous recevoir votre commande ?
+                      {t("checkout.shipping.subtitle")}
                     </p>
                   </div>
                 </div>
@@ -226,7 +228,7 @@ export function Checkout() {
               <CardContent className="space-y-4">
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <Input
-                    label="Nom complet"
+                    label={t("checkout.shipping.name")}
                     value={shippingAddress.name}
                     onChange={(e) =>
                       setShippingAddress({
@@ -234,10 +236,10 @@ export function Checkout() {
                         name: e.target.value,
                       })
                     }
-                    placeholder="Votre nom complet"
+                    placeholder={t("checkout.shipping.namePlaceholder")}
                   />
                   <Input
-                    label="Téléphone"
+                    label={t("checkout.shipping.phone")}
                     value={shippingAddress.phone}
                     onChange={(e) =>
                       setShippingAddress({
@@ -245,12 +247,12 @@ export function Checkout() {
                         phone: e.target.value,
                       })
                     }
-                    placeholder="Votre numéro de téléphone"
+                    placeholder={t("checkout.shipping.phonePlaceholder")}
                   />
                 </div>
 
                 <Input
-                  label="Adresse"
+                  label={t("checkout.shipping.address")}
                   value={shippingAddress.address}
                   onChange={(e) =>
                     setShippingAddress({
@@ -258,12 +260,12 @@ export function Checkout() {
                       address: e.target.value,
                     })
                   }
-                  placeholder="Adresse complète"
+                  placeholder={t("checkout.shipping.addressPlaceholder")}
                 />
 
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                   <Input
-                    label="Ville"
+                    label={t("checkout.shipping.city")}
                     value={shippingAddress.city}
                     onChange={(e) =>
                       setShippingAddress({
@@ -271,10 +273,10 @@ export function Checkout() {
                         city: e.target.value,
                       })
                     }
-                    placeholder="Ville"
+                    placeholder={t("checkout.shipping.city")}
                   />
                   <Input
-                    label="Code postal"
+                    label={t("checkout.shipping.postalCode")}
                     value={shippingAddress.postal_code}
                     onChange={(e) =>
                       setShippingAddress({
@@ -282,10 +284,10 @@ export function Checkout() {
                         postal_code: e.target.value,
                       })
                     }
-                    placeholder="Code postal"
+                    placeholder={t("checkout.shipping.postalCode")}
                   />
                   <Input
-                    label="Pays"
+                    label={t("checkout.shipping.country")}
                     value={shippingAddress.country}
                     onChange={(e) =>
                       setShippingAddress({
@@ -293,7 +295,7 @@ export function Checkout() {
                         country: e.target.value,
                       })
                     }
-                    placeholder="Pays"
+                    placeholder={t("checkout.shipping.country")}
                   />
                 </div>
 
@@ -306,7 +308,7 @@ export function Checkout() {
                     onClick={saveAddressToProfile}
                     className="w-full md:w-auto"
                   >
-                    Sauvegarder dans mon profil
+                    {t("checkout.shipping.save")}
                   </Button>
                 )}
               </CardContent>
@@ -322,10 +324,10 @@ export function Checkout() {
                 </div>
                 <div>
                   <h2 className="text-xl font-light text-foreground">
-                    Méthode de paiement
+                    {t("checkout.payment.title")}
                   </h2>
                   <p className="text-muted-foreground/70">
-                    Sécurisé par PayPal
+                    {t("checkout.payment.securedBy")}
                   </p>
                 </div>
               </div>

--- a/src/pages/Creator/CreateProduct.tsx
+++ b/src/pages/Creator/CreateProduct.tsx
@@ -16,6 +16,7 @@ import {
 import supabase from "../../lib/supabase";
 import { Save, Upload, ArrowLeft, Plus } from "lucide-react";
 import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
 
 export function CreateProduct() {
   const { user } = useAuth();
@@ -36,6 +37,7 @@ export function CreateProduct() {
     status: "draft" as "draft" | "active",
     images: [] as string[],
   });
+  const { t } = useTranslation();
 
   useEffect(() => {
     fetchInitialData();
@@ -56,7 +58,7 @@ export function CreateProduct() {
       setCategories(categoriesResult.data || []);
 
       if (!shopResult.data) {
-        toast.error("Veuillez créer votre boutique d'abord");
+        toast.error(t("createProduct.needShop"));
         navigate("/creator/shop");
         return;
       }
@@ -94,11 +96,11 @@ export function CreateProduct() {
 
       if (error) throw error;
 
-      toast.success("Produit créé avec succès !");
+      toast.success(t("createProduct.success"));
       navigate("/dashboard/creator");
     } catch (error: any) {
       console.error("Erreur lors de la création du produit:", error);
-      toast.error(error.message || "Échec de la création du produit");
+      toast.error(error.message || t("createProduct.error"));
     } finally {
       setSaving(false);
     }

--- a/src/pages/Creator/EditProduct.tsx
+++ b/src/pages/Creator/EditProduct.tsx
@@ -16,6 +16,7 @@ import {
 import supabase from "../../lib/supabase";
 import { Save, ArrowLeft, Edit3 } from "lucide-react";
 import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
 
 export function EditProduct() {
   const { user } = useAuth();
@@ -37,6 +38,7 @@ export function EditProduct() {
     status: "draft" as "draft" | "active" | "paused" | "sold_out",
     images: [] as string[],
   });
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (productId) {
@@ -57,20 +59,20 @@ export function EditProduct() {
       ]);
 
       if (!shopResult.data) {
-        toast.error("Veuillez créer votre boutique d'abord");
+        toast.error(t("editProduct.needShop"));
         navigate("/creator/shop");
         return;
       }
 
       if (!productResult.data) {
-        toast.error("Produit non trouvé");
+        toast.error(t("editProduct.notFound"));
         navigate("/dashboard/creator");
         return;
       }
 
       // Vérifier que l'utilisateur est propriétaire du produit
       if (productResult.data.shop_id !== shopResult.data.id) {
-        toast.error("Accès non autorisé");
+        toast.error(t("editProduct.unauthorized"));
         navigate("/dashboard/creator");
         return;
       }
@@ -94,7 +96,7 @@ export function EditProduct() {
       });
     } catch (error) {
       console.error("Erreur lors de la récupération des données:", error);
-      toast.error("Erreur lors du chargement du produit");
+      toast.error(t("editProduct.loadError"));
     } finally {
       setLoading(false);
     }
@@ -133,11 +135,11 @@ export function EditProduct() {
 
       if (error) throw error;
 
-      toast.success("Produit mis à jour avec succès !");
+      toast.success(t("editProduct.success"));
       navigate("/dashboard/creator");
     } catch (error: any) {
       console.error("Erreur lors de la mise à jour du produit:", error);
-      toast.error(error.message || "Échec de la mise à jour du produit");
+      toast.error(error.message || t("editProduct.error"));
     } finally {
       setSaving(false);
     }

--- a/src/pages/CreatorProfile.tsx
+++ b/src/pages/CreatorProfile.tsx
@@ -7,6 +7,7 @@ import { ServiceCard } from "../components/Cards/ServiceCard";
 import { LoadingSpinner } from "../components/UI/LoadingSpinner";
 import { Button } from "../components/UI/Button";
 import { Card, CardHeader, CardContent } from "../components/UI/Card";
+import { useTranslation } from "react-i18next";
 
 export function CreatorProfile() {
   const { slug } = useParams<{ slug: string }>();
@@ -15,6 +16,7 @@ export function CreatorProfile() {
   const [services, setServices] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState("products");
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (slug) {
@@ -48,10 +50,10 @@ export function CreatorProfile() {
       ]);
 
       setProducts(
-        productsResult.data?.map((p) => ({ ...p, shop: shopData })) || []
+        productsResult.data?.map((p) => ({ ...p, shop: shopData })) || [],
       );
       setServices(
-        servicesResult.data?.map((s) => ({ ...s, shop: shopData })) || []
+        servicesResult.data?.map((s) => ({ ...s, shop: shopData })) || [],
       );
     } catch (error) {
       console.error("Error fetching creator data:", error);
@@ -72,7 +74,7 @@ export function CreatorProfile() {
     return (
       <div className="max-w-7xl mx-auto px-6 lg:px-8 py-12 text-center">
         <h1 className="text-2xl font-light text-foreground">
-          Boutique introuvable
+          {t("creatorProfile.notFound")}
         </h1>
       </div>
     );
@@ -87,7 +89,7 @@ export function CreatorProfile() {
           {shop.banner_url ? (
             <img
               src={shop.banner_url}
-              alt={`Bannière de ${shop.name}`}
+              alt={t("creatorProfile.bannerAlt", { shopName: shop.name })}
               className="w-full h-full object-cover"
             />
           ) : (
@@ -126,7 +128,7 @@ export function CreatorProfile() {
                   {shop.is_verified && (
                     <div className="bg-primary text-primary-foreground text-xs px-3 py-1 rounded-full font-medium flex items-center">
                       <Star className="h-3 w-3 mr-1" />
-                      Vérifié
+                      {t("creatorProfile.verified")}
                     </div>
                   )}
                 </div>
@@ -142,11 +144,13 @@ export function CreatorProfile() {
                     <Star className="h-4 w-4 mr-2 text-primary" />
                     {shop.rating_avg
                       ? `${shop.rating_avg.toFixed(1)}/5`
-                      : "Nouveau"}
+                      : t("creatorProfile.new")}
                   </div>
                   <div className="flex items-center">
                     <Calendar className="h-4 w-4 mr-2 text-primary" />
-                    Membre depuis {new Date(shop.created_at).getFullYear()}
+                    {t("creatorProfile.memberSince", {
+                      year: new Date(shop.created_at).getFullYear(),
+                    })}
                   </div>
                 </div>
 
@@ -170,7 +174,9 @@ export function CreatorProfile() {
           className="flex items-center space-x-2"
         >
           <Package className="h-5 w-5" />
-          <span>Produits ({products.length})</span>
+          <span>
+            {t("creatorProfile.tabs.products", { count: products.length })}
+          </span>
         </Button>
         <Button
           variant={activeTab === "services" ? "primary" : "ghost"}
@@ -179,7 +185,9 @@ export function CreatorProfile() {
           className="flex items-center space-x-2"
         >
           <Briefcase className="h-5 w-5" />
-          <span>Services ({services.length})</span>
+          <span>
+            {t("creatorProfile.tabs.services", { count: services.length })}
+          </span>
         </Button>
       </div>
 
@@ -196,10 +204,10 @@ export function CreatorProfile() {
                 <Package className="h-10 w-10 text-muted-foreground" />
               </div>
               <h3 className="text-xl font-light text-foreground mb-2">
-                Aucun produit disponible
+                {t("creatorProfile.productsEmptyTitle")}
               </h3>
               <p className="text-muted-foreground/70">
-                Cette boutique n'a pas encore de produits
+                {t("creatorProfile.productsEmptySubtitle")}
               </p>
             </div>
           )
@@ -213,10 +221,10 @@ export function CreatorProfile() {
               <Briefcase className="h-10 w-10 text-muted-foreground" />
             </div>
             <h3 className="text-xl font-light text-foreground mb-2">
-              Aucun service disponible
+              {t("creatorProfile.servicesEmptyTitle")}
             </h3>
             <p className="text-muted-foreground/70">
-              Cette boutique n'a pas encore de services
+              {t("creatorProfile.servicesEmptySubtitle")}
             </p>
           </div>
         )}

--- a/src/pages/Dashboard/BuyerDashboard.tsx
+++ b/src/pages/Dashboard/BuyerDashboard.tsx
@@ -13,12 +13,14 @@ import {
 import { LoadingSpinner } from "../../components/UI/LoadingSpinner";
 import { Button } from "../../components/UI/Button";
 import { Card, CardHeader, CardContent } from "../../components/UI/Card";
+import { useTranslation } from "react-i18next";
 
 export function BuyerDashboard() {
   const { user } = useAuth();
   const [orders, setOrders] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState("all");
+  const { t, i18n } = useTranslation();
 
   useEffect(() => {
     if (user) {
@@ -82,13 +84,13 @@ export function BuyerDashboard() {
   const getStatusText = (status: string) => {
     switch (status) {
       case "paid":
-        return "Payé";
+        return t("common.orderStatus.paid");
       case "processing":
-        return "En traitement";
+        return t("common.orderStatus.processing");
       case "completed":
-        return "Terminé";
+        return t("common.orderStatus.completed");
       case "shipped":
-        return "Expédié";
+        return t("common.orderStatus.shipped");
       default:
         return status.replace("_", " ");
     }
@@ -112,10 +114,10 @@ export function BuyerDashboard() {
       {/* Header */}
       <div className="mb-12">
         <h1 className="text-4xl md:text-5xl font-light text-foreground tracking-tight mb-4">
-          Tableau de Bord
+          {t("buyerDashboard.title")}
         </h1>
         <p className="text-muted-foreground/70 text-lg">
-          Suivez vos commandes et gérez vos achats
+          {t("buyerDashboard.subtitle")}
         </p>
       </div>
 
@@ -126,7 +128,7 @@ export function BuyerDashboard() {
             {orders.length}
           </div>
           <div className="text-muted-foreground/70 text-sm">
-            Total des commandes
+            {t("buyerDashboard.stats.total")}
           </div>
         </Card>
 
@@ -135,7 +137,7 @@ export function BuyerDashboard() {
             {orders.filter((o) => o.status === "completed").length}
           </div>
           <div className="text-muted-foreground/70 text-sm">
-            Commandes terminées
+            {t("buyerDashboard.stats.completed")}
           </div>
         </Card>
 
@@ -147,14 +149,18 @@ export function BuyerDashboard() {
               ).length
             }
           </div>
-          <div className="text-muted-foreground/70 text-sm">En cours</div>
+          <div className="text-muted-foreground/70 text-sm">
+            {t("buyerDashboard.stats.inProgress")}
+          </div>
         </Card>
 
         <Card className="text-center p-6">
           <div className="text-3xl font-light text-foreground mb-2">
             {orders.filter((o) => o.status === "paid").length}
           </div>
-          <div className="text-muted-foreground/70 text-sm">En attente</div>
+          <div className="text-muted-foreground/70 text-sm">
+            {t("buyerDashboard.stats.pending")}
+          </div>
         </Card>
       </div>
 
@@ -167,7 +173,7 @@ export function BuyerDashboard() {
             size="sm"
             onClick={() => setActiveTab(tab)}
           >
-            {tab === "all" ? "Toutes" : getStatusText(tab)}
+            {tab === "all" ? t("buyerDashboard.tabs.all") : t(`common.orderStatus.${tab}`)}
           </Button>
         ))}
       </div>
@@ -178,14 +184,14 @@ export function BuyerDashboard() {
           <Card className="text-center p-16">
             <Package className="h-16 w-16 text-muted-foreground/40 mx-auto mb-6" />
             <h3 className="text-xl font-light text-foreground mb-2">
-              Aucune commande trouvée
+              {t("buyerDashboard.empty.title")}
             </h3>
             <p className="text-muted-foreground/70">
               {activeTab === "all"
-                ? "Vous n'avez pas encore passé de commande."
-                : `Aucune commande avec le statut "${getStatusText(
-                    activeTab
-                  )}".`}
+                ? t("buyerDashboard.empty.all")
+                : t("buyerDashboard.empty.status", {
+                    status: t(`common.orderStatus.${activeTab}`),
+                  })}
             </p>
           </Card>
         ) : (
@@ -195,14 +201,19 @@ export function BuyerDashboard() {
                 <div className="flex items-center justify-between">
                   <div>
                     <h3 className="text-lg font-light text-foreground">
-                      Commande #{order.id.slice(-8)}
+                      {t("buyerDashboard.order.title", {
+                        id: order.id.slice(-8),
+                      })}
                     </h3>
                     <p className="text-muted-foreground/70 text-sm">
-                      {new Date(order.created_at).toLocaleDateString("fr-FR", {
-                        year: "numeric",
-                        month: "long",
-                        day: "numeric",
-                      })}
+                      {new Date(order.created_at).toLocaleDateString(
+                        i18n.language === "fr" ? "fr-FR" : "en-US",
+                        {
+                          year: "numeric",
+                          month: "long",
+                          day: "numeric",
+                        }
+                      )}
                     </p>
                   </div>
                   <div className="text-right">
@@ -234,10 +245,13 @@ export function BuyerDashboard() {
                       <div className="flex items-center justify-between">
                         <div>
                           <h4 className="text-foreground font-medium">
-                            {item.title || "Article"}
+                            {item.title || t("common.item")}
                           </h4>
                           <p className="text-muted-foreground/70 text-sm">
-                            De {item.shop?.name} • Qté: {item.qty}
+                            {t("buyerDashboard.order.from", {
+                              shopName: item.shop?.name,
+                              qty: item.qty,
+                            })}
                           </p>
                         </div>
                         <div className="flex items-center space-x-4">
@@ -261,7 +275,7 @@ export function BuyerDashboard() {
                             icon={MessageSquare}
                             className="text-primary hover:text-primary/80"
                           >
-                            Contacter le vendeur
+                            {t("buyerDashboard.order.contactSeller")}
                           </Button>
                           <Button
                             variant="ghost"
@@ -269,7 +283,7 @@ export function BuyerDashboard() {
                             icon={Star}
                             className="text-primary hover:text-primary/80"
                           >
-                            Laisser un avis
+                            {t("buyerDashboard.order.leaveReview")}
                           </Button>
                         </div>
                       )}
@@ -278,7 +292,7 @@ export function BuyerDashboard() {
                       {item.tracking && (
                         <div className="mt-3 p-3 glass rounded-xl border border-border/30">
                           <p className="text-sm text-foreground">
-                            <strong>Suivi :</strong> {item.tracking}
+                            <strong>{t("buyerDashboard.order.tracking")}</strong> {item.tracking}
                           </p>
                         </div>
                       )}
@@ -287,9 +301,9 @@ export function BuyerDashboard() {
                       {item.delivery_date && (
                         <div className="mt-3 p-3 glass rounded-xl border border-border/30">
                           <p className="text-sm text-foreground">
-                            <strong>Livraison prévue :</strong>{" "}
+                            <strong>{t("buyerDashboard.order.delivery")}</strong>{" "}
                             {new Date(item.delivery_date).toLocaleDateString(
-                              "fr-FR"
+                              i18n.language === "fr" ? "fr-FR" : "en-US"
                             )}
                           </p>
                         </div>

--- a/src/pages/Dashboard/CreatorDashboard.tsx
+++ b/src/pages/Dashboard/CreatorDashboard.tsx
@@ -21,6 +21,7 @@ import { ShippingManager } from "../../components/Creator/ShippingManager";
 import { StockAlerts } from "../../components/Creator/StockAlerts";
 import { SalesAnalytics } from "../../components/Creator/SalesAnalytics";
 import { StockInfoCard } from "../../components/Creator/StockInfoCard";
+import { useTranslation } from "react-i18next";
 
 export function CreatorDashboard() {
   const { user, profile } = useAuth();
@@ -34,6 +35,7 @@ export function CreatorDashboard() {
   });
   const [recentOrders, setRecentOrders] = useState<OrderItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (user) {
@@ -110,15 +112,14 @@ export function CreatorDashboard() {
             <Store className="h-12 w-12 text-primary" />
           </div>
           <h1 className="text-4xl font-light text-foreground tracking-tight mb-4">
-            Bienvenue dans votre Studio Créateur
+            {t("creatorDashboard.welcome.title")}
           </h1>
           <p className="text-muted-foreground/70 text-lg mb-8">
-            Configurez votre boutique pour commencer à vendre vos œuvres d'art
-            et services incroyables
+            {t("creatorDashboard.welcome.subtitle")}
           </p>
           <Link to="/creator/shop">
             <Button variant="gradient" size="lg" icon={Plus}>
-              Créer votre boutique
+              {t("creatorDashboard.welcome.createShop")}
             </Button>
           </Link>
         </div>
@@ -136,10 +137,10 @@ export function CreatorDashboard() {
           </div>
           <div>
             <h1 className="text-3xl md:text-4xl font-light text-foreground tracking-tight">
-              Studio Créateur
+              {t("creatorDashboard.header.title")}
             </h1>
             <p className="text-muted-foreground/70 text-base md:text-lg">
-              {shop.name} • Gérez vos créations
+              {t("creatorDashboard.header.subtitle", { shopName: shop.name })}
             </p>
           </div>
         </div>
@@ -151,7 +152,7 @@ export function CreatorDashboard() {
               icon={Plus}
               className="w-full sm:w-auto"
             >
-              Ajouter un produit
+              {t("creatorDashboard.actions.addProduct")}
             </Button>
           </Link>
           <Link to="/creator/services/new">
@@ -161,7 +162,7 @@ export function CreatorDashboard() {
               icon={Plus}
               className="w-full sm:w-auto"
             >
-              Ajouter un service
+              {t("creatorDashboard.actions.addService")}
             </Button>
           </Link>
         </div>
@@ -180,11 +181,13 @@ export function CreatorDashboard() {
             {stats.products.toLocaleString()}
           </div>
           <div className="text-muted-foreground/70 text-xs md:text-sm">
-            Produits
+            {t("creatorDashboard.stats.products")}
           </div>
           {stats.productsInCarts > 0 && (
             <div className="text-xs text-orange-500 mt-1">
-              dont {stats.productsInCarts} en paniers
+              {t("creatorDashboard.stats.inCarts", {
+                count: stats.productsInCarts,
+              })}
             </div>
           )}
         </Card>
@@ -197,7 +200,7 @@ export function CreatorDashboard() {
             {stats.services.toLocaleString()}
           </div>
           <div className="text-muted-foreground/70 text-xs md:text-sm">
-            Services
+            {t("creatorDashboard.stats.services")}
           </div>
         </Card>
 
@@ -209,7 +212,7 @@ export function CreatorDashboard() {
             {stats.orders.toLocaleString()}
           </div>
           <div className="text-muted-foreground/70 text-xs md:text-sm">
-            Commandes
+            {t("creatorDashboard.stats.orders")}
           </div>
         </Card>
 
@@ -221,7 +224,7 @@ export function CreatorDashboard() {
             ${stats.revenue.toLocaleString()}
           </div>
           <div className="text-muted-foreground/70 text-xs md:text-sm">
-            Revenus
+            {t("creatorDashboard.stats.revenue")}
           </div>
         </Card>
       </div>
@@ -250,10 +253,10 @@ export function CreatorDashboard() {
         <CardHeader>
           <div className="flex items-center justify-between">
             <h2 className="text-2xl font-light text-foreground tracking-tight">
-              Activité Récente
+              {t("creatorDashboard.recent.title")}
             </h2>
             <Button variant="ghost" size="sm">
-              Voir toutes les commandes
+              {t("creatorDashboard.recent.viewAll")}
             </Button>
           </div>
         </CardHeader>
@@ -262,10 +265,10 @@ export function CreatorDashboard() {
             <div className="text-center py-8">
               <TrendingUp className="h-12 w-12 text-muted-foreground/40 mx-auto mb-3" />
               <p className="text-muted-foreground/70">
-                Aucune commande récente
+                {t("creatorDashboard.recent.emptyTitle")}
               </p>
               <p className="text-muted-foreground/60 text-sm mt-1">
-                Les nouvelles commandes apparaîtront ici
+                {t("creatorDashboard.recent.emptySubtitle")}
               </p>
             </div>
           ) : (
@@ -277,7 +280,9 @@ export function CreatorDashboard() {
                 >
                   <div className="flex items-center justify-between mb-2">
                     <h3 className="text-foreground font-medium text-sm">
-                      Commande #{item.id.slice(-6)}
+                      {t("creatorDashboard.recent.order", {
+                        id: item.id.slice(-6),
+                      })}
                     </h3>
                     <div
                       className={`text-xs font-medium px-2 py-1 rounded-full ${
@@ -289,10 +294,10 @@ export function CreatorDashboard() {
                       }`}
                     >
                       {item.status === "completed"
-                        ? "Complétée"
+                        ? t("common.orderStatus.completed")
                         : item.status === "shipped"
-                        ? "Expédiée"
-                        : "En cours"}
+                        ? t("common.orderStatus.shipped")
+                        : t("common.orderStatus.processing")}
                     </div>
                   </div>
                   <div className="text-right">
@@ -300,7 +305,7 @@ export function CreatorDashboard() {
                       ${(item.unit_price * item.qty).toFixed(2)}
                     </div>
                     <p className="text-muted-foreground/70 text-xs">
-                      Qté: {item.qty}
+                      {t("creatorDashboard.recent.qty", { count: item.qty })}
                     </p>
                   </div>
                 </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import {
   Search,
   Palette,
@@ -16,10 +17,12 @@ import {
 import { ArtistCarousel } from "../components/UI/ArtistCarousel";
 
 export function Home() {
+  const { t } = useTranslation();
+
   const featuredCategories = [
     {
       name: "Card Alters",
-      description: "Transformez vos cartes préférées en œuvres d'art uniques",
+      description: t("home.featuredCategories.cardAlters.description"),
       image:
         "https://draftsim.com/wp-content/uploads/2023/10/To-the-Slaughter-Illustration-by-Christine-Choi-1024x636.jpg",
       link: "/search?category=Card+Alters",
@@ -27,7 +30,7 @@ export function Home() {
     },
     {
       name: "Custom Tokens",
-      description: "Jetons et pièces de jeu professionnels",
+      description: t("home.featuredCategories.customTokens.description"),
       image:
         "https://draftsim.com/wp-content/uploads/2022/06/Banishing-Light-%E2%80%93-Will-Murai-1024x748.jpg",
       link: "/search?category=Custom+Tokens",
@@ -35,7 +38,7 @@ export function Home() {
     },
     {
       name: "Deckbuilding",
-      description: "Améliorez votre gameplay avec des conseils d'experts",
+      description: t("home.featuredCategories.deckbuilding.description"),
       image:
         "https://draftsim.com/wp-content/uploads/2022/06/Promise-of-Tomorrow-%E2%80%93-Seb-McKinnon-2-1024x749.jpg",
       link: "/search?type=service&category=Deckbuilding",
@@ -43,7 +46,7 @@ export function Home() {
     },
     {
       name: "Playmats",
-      description: "Tapis de jeu, boîtes de deck et accessoires personnalisés",
+      description: t("home.featuredCategories.playmats.description"),
       image:
         "https://draftsim.com/wp-content/uploads/2022/06/Gods-Demigods-Constellation-%E2%80%93-Jason-A.-Engle-1-1024x606.jpg",
       link: "/search?category=Playmats",
@@ -69,15 +72,15 @@ export function Home() {
           <div className="animate-fade-in">
             <div className="inline-flex items-center px-6 py-3 rounded-2xl glass text-primary text-sm font-light mb-12 border border-primary/30">
               <Sparkles className="w-4 h-4 mr-2" />
-              L'Artisanat Magique de Référence
+              {t("home.hero.tagline")}
             </div>
           </div>
 
           <h1 className="text-5xl md:text-7xl font-light mb-8 text-foreground leading-tight animate-fade-in tracking-tight">
             <div className="flex flex-col md:flex-row items-center justify-center gap-2 md:gap-6">
-              <span>Boutiques</span>
-              <span className="text-primary">d'Art</span>
-              <span>Magique</span>
+              <span>{t("home.hero.title.part1")}</span>
+              <span className="text-primary">{t("home.hero.title.part2")}</span>
+              <span>{t("home.hero.title.part3")}</span>
             </div>
           </h1>
 
@@ -85,8 +88,7 @@ export function Home() {
             className="text-lg md:text-xl lg:text-2xl text-muted-foreground/80 mb-12 max-w-4xl mx-auto leading-relaxed animate-fade-in px-4"
             style={{ animationDelay: "0.2s" }}
           >
-            Découvrez des alters de cartes uniques, des jetons et des créations
-            magiques d'artistes talentueux du monde entier
+            {t("home.hero.description")}
           </p>
 
           <div
@@ -99,7 +101,7 @@ export function Home() {
             >
               <span className="block px-8 md:px-10 py-4 md:py-5 text-sm md:text-base font-medium text-foreground hover:text-primary transition-colors duration-300 bg-card">
                 <Search className="inline mr-2 h-5 w-5" />
-                Explorer les Boutiques
+                {t("home.hero.explore")}
                 <ArrowRight className="inline ml-2 h-5 w-5 group-hover:translate-x-2 transition-transform duration-300" />
               </span>
             </Link>
@@ -107,7 +109,7 @@ export function Home() {
               to="/auth/signup"
               className="px-8 md:px-10 py-4 md:py-5 rounded-2xl font-medium transition-all duration-300 text-sm md:text-base glass border border-border/30 hover:border-primary/30 hover:text-primary hover:scale-[1.02] transform"
             >
-              Devenir Créateur
+              {t("home.hero.becomeCreator")}
             </Link>
           </div>
 
@@ -121,21 +123,21 @@ export function Home() {
                 500+
               </div>
               <div className="text-muted-foreground/60 text-sm">
-                Artistes Actifs
+                {t("home.hero.stats.artists")}
               </div>
             </div>
             <div className="text-center">
               <div className="text-3xl md:text-4xl lg:text-5xl font-light text-foreground mb-2">
                 50+
               </div>
-              <div className="text-muted-foreground/60 text-sm">Pays</div>
+              <div className="text-muted-foreground/60 text-sm">{t("home.hero.stats.countries")}</div>
             </div>
             <div className="text-center">
               <div className="text-3xl md:text-4xl lg:text-5xl font-light text-foreground mb-2">
                 99%
               </div>
               <div className="text-muted-foreground/60 text-sm">
-                Satisfaction
+                {t("home.hero.stats.satisfaction")}
               </div>
             </div>
           </div>
@@ -146,10 +148,10 @@ export function Home() {
       <section className="max-w-7xl mx-auto px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-light mb-6 text-foreground px-4 tracking-tight">
-            Catégories Populaires
+            {t("home.categories.title")}
           </h2>
           <p className="text-lg md:text-xl text-muted-foreground/70 max-w-2xl mx-auto px-4">
-            Découvrez les créations les plus demandées par nos clients
+            {t("home.categories.subtitle")}
           </p>
         </div>
 
@@ -164,7 +166,7 @@ export function Home() {
                 <div className="absolute top-4 left-4 z-10">
                   <div className="bg-primary text-primary-foreground text-xs px-3 py-1 rounded-full font-medium flex items-center">
                     <Star className="h-3 w-3 mr-1" />
-                    Populaire
+                    {t("home.categories.popular")}
                   </div>
                 </div>
               )}
@@ -196,11 +198,10 @@ export function Home() {
       <section className="max-w-7xl mx-auto px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-light mb-6 text-foreground px-4 tracking-tight">
-            Artistes Populaires
+            {t("home.artists.title")}
           </h2>
           <p className="text-lg md:text-xl text-muted-foreground/70 max-w-2xl mx-auto px-4">
-            Découvrez nos artistes les plus talentueux et leurs créations
-            uniques
+            {t("home.artists.subtitle")}
           </p>
         </div>
 
@@ -212,11 +213,10 @@ export function Home() {
         <div className="max-w-7xl mx-auto px-6 lg:px-8">
           <div className="text-center mb-20">
             <h2 className="text-3xl md:text-4xl lg:text-5xl font-light mb-6 text-foreground tracking-tight">
-              Pourquoi Choisir ManaShop ?
+              {t("home.features.title")}
             </h2>
             <p className="text-lg md:text-xl text-muted-foreground/70 max-w-3xl mx-auto">
-              Les boutiques d'art de confiance pour vos créations magiques de
-              qualité
+              {t("home.features.subtitle")}
             </p>
           </div>
 
@@ -226,11 +226,10 @@ export function Home() {
                 <Award className="w-10 h-10 text-primary" />
               </div>
               <h3 className="text-xl md:text-2xl font-light text-foreground mb-4">
-                Artistes Vérifiés
+                {t("home.features.verified.title")}
               </h3>
               <p className="text-muted-foreground/70 text-center leading-relaxed">
-                Tous les artistes sont des professionnels vérifiés garantissant
-                un travail de qualité pour vos cartes.
+                {t("home.features.verified.description")}
               </p>
             </div>
             <div className="text-center">
@@ -238,11 +237,10 @@ export function Home() {
                 <Users className="w-10 h-10 text-primary" />
               </div>
               <h3 className="text-xl md:text-2xl font-light text-foreground mb-4">
-                Réseau Mondial
+                {t("home.features.network.title")}
               </h3>
               <p className="text-muted-foreground/70 text-center leading-relaxed">
-                Connectez-vous avec des artistes talentueux du monde entier,
-                chacun apportant des compétences et une expertise uniques.
+                {t("home.features.network.description")}
               </p>
             </div>
             <div className="text-center">
@@ -250,11 +248,10 @@ export function Home() {
                 <TrendingUp className="w-10 h-10 text-primary" />
               </div>
               <h3 className="text-xl md:text-2xl font-light text-foreground mb-4">
-                Transactions Sécurisées
+                {t("home.features.secure.title")}
               </h3>
               <p className="text-muted-foreground/70 text-center leading-relaxed">
-                Paiements sécurisés avec protection de l'acheteur et garanties
-                de satisfaction.
+                {t("home.features.secure.description")}
               </p>
             </div>
           </div>
@@ -268,11 +265,10 @@ export function Home() {
 
           <div className="relative z-10">
             <h2 className="text-3xl md:text-4xl lg:text-5xl font-light mb-6 text-foreground tracking-tight">
-              Prêt à Trouver Votre Artiste Parfait ?
+              {t("home.cta.title")}
             </h2>
             <p className="text-lg md:text-xl text-muted-foreground/80 mb-10 max-w-3xl mx-auto leading-relaxed">
-              Rejoignez des milliers de joueurs qui ont découvert des œuvres
-              d'art magiques incroyables
+              {t("home.cta.subtitle")}
             </p>
             <Link
               to="/search"
@@ -280,7 +276,7 @@ export function Home() {
             >
               <span className="block px-10 md:px-12 py-4 md:py-5 text-sm md:text-base font-medium text-foreground hover:text-primary transition-colors duration-300 bg-card">
                 <Palette className="inline mr-2 h-5 w-5" />
-                Découvrir les Boutiques
+                {t("home.cta.explore")}
                 <ArrowRight className="inline ml-2 h-5 w-5 group-hover:translate-x-2 transition-transform duration-300" />
               </span>
             </Link>

--- a/src/pages/NotificationPreferences.tsx
+++ b/src/pages/NotificationPreferences.tsx
@@ -8,6 +8,7 @@ import {
   NotificationChannel,
 } from "../types/notifications";
 import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
 
 const categories = [
   {
@@ -61,6 +62,7 @@ export function NotificationPreferences() {
   const queryClient = useQueryClient();
   const [preferences, setPreferences] = useState<Record<string, boolean>>({});
   const [hasChanges, setHasChanges] = useState(false);
+  const { t } = useTranslation();
 
   // Récupérer les préférences actuelles
   const { data: currentPreferences = [], isLoading } = useQuery({
@@ -80,10 +82,10 @@ export function NotificationPreferences() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["notification-preferences"] });
       setHasChanges(false);
-      toast.success("Préférences sauvegardées avec succès");
+      toast.success(t("notificationPreferences.saveSuccess"));
     },
     onError: (error) => {
-      toast.error("Erreur lors de la sauvegarde des préférences");
+      toast.error(t("notificationPreferences.saveError"));
       console.error("Error saving preferences:", error);
     },
   });

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -20,6 +20,7 @@ import { Button } from "../components/UI/Button";
 import { Card, CardHeader, CardContent } from "../components/UI/Card";
 import { ProductViewTracker } from "../components/Analytics";
 import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
 
 export function ProductDetail() {
   const { id } = useParams<{ id: string }>();
@@ -29,6 +30,7 @@ export function ProductDetail() {
   const [quantity, setQuantity] = useState(1);
   const { addToCart } = useCart();
   const { checkStock } = useStockCheck();
+  const { t } = useTranslation();
 
   // Utiliser le hook de monitoring du stock
   const { stockInfo, refetchStock } = useStockMonitoring(
@@ -60,7 +62,7 @@ export function ProductDetail() {
       setProduct(data);
     } catch (error) {
       console.error("Erreur lors de la récupération du produit:", error);
-      toast.error("Produit non trouvé");
+      toast.error(t("productDetail.notFound"));
     } finally {
       setLoading(false);
     }
@@ -74,7 +76,7 @@ export function ProductDetail() {
       const stock = await checkStock(product.id, quantity);
       if (!stock.available) {
         toast.error(
-          `Stock insuffisant. Seulement ${stock.availableStock} article(s) disponible(s)`
+          t("cart.stockInsufficient", { stock: stock.availableStock })
         );
         return;
       }
@@ -99,9 +101,9 @@ export function ProductDetail() {
         refetchStock();
       }
 
-      toast.success("Produit ajouté au panier !");
+      toast.success(t("productDetail.addSuccess"));
     } catch (error) {
-      toast.error("Échec de l'ajout au panier");
+      toast.error(t("productDetail.addError"));
     }
   };
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -5,10 +5,12 @@ import toast from "react-hot-toast";
 import { Button } from "../components/UI/Button";
 import { Input } from "../components/UI/Input";
 import { Card, CardHeader, CardContent } from "../components/UI/Card";
+import { useTranslation } from "react-i18next";
 
 export function Profile() {
   const { profile, updateProfile } = useAuth();
   const [saving, setSaving] = useState(false);
+  const { t } = useTranslation();
   const [formData, setFormData] = useState({
     display_name: profile?.display_name || "",
     bio: profile?.bio || "",
@@ -28,9 +30,9 @@ export function Profile() {
       const { error } = await updateProfile(formData);
       if (error) throw error;
 
-      toast.success("Profil mis à jour avec succès !");
+      toast.success(t("profile.updateSuccess"));
     } catch (error: any) {
-      toast.error(error.message || "Échec de la mise à jour du profil");
+      toast.error(error.message || t("profile.updateError"));
     } finally {
       setSaving(false);
     }
@@ -40,10 +42,10 @@ export function Profile() {
     <div className="max-w-6xl mx-auto px-6 lg:px-8 py-12">
       <div className="mb-12">
         <h1 className="text-4xl font-light text-foreground tracking-tight mb-4">
-          Paramètres du Profil
+          {t("profile.title")}
         </h1>
         <p className="text-muted-foreground/70 text-lg">
-          Gérez vos informations personnelles et vos préférences
+          {t("profile.subtitle")}
         </p>
       </div>
 
@@ -63,15 +65,10 @@ export function Profile() {
             </div>
             <div>
               <h2 className="text-2xl font-light text-foreground">
-                {profile?.display_name || "Anonyme"}
+                {profile?.display_name || t("profile.anonymous")}
               </h2>
               <p className="text-muted-foreground/70 capitalize">
-                Compte{" "}
-                {profile?.role === "creator"
-                  ? "créateur"
-                  : profile?.role === "admin"
-                  ? "administrateur"
-                  : "acheteur"}
+                {t(`profile.roles.${profile?.role || "buyer"}`)}
               </p>
             </div>
           </div>
@@ -83,22 +80,22 @@ export function Profile() {
             <div className="space-y-6">
               <h3 className="text-lg font-medium text-foreground flex items-center">
                 <MapPin className="h-5 w-5 mr-2 text-primary" />
-                Adresse de livraison
+                {t("profile.delivery.title")}
               </h3>
 
               <div className="space-y-4">
                 <Input
-                  label="Nom complet"
+                  label={t("profile.delivery.name")}
                   value={formData.shipping_name}
                   onChange={(e) =>
                     setFormData({ ...formData, shipping_name: e.target.value })
                   }
-                  placeholder="Jean Dupont"
+                  placeholder={t("profile.delivery.namePlaceholder")}
                   id="shipping_name"
                 />
 
                 <Input
-                  label="Adresse"
+                  label={t("profile.delivery.address")}
                   value={formData.shipping_address}
                   onChange={(e) =>
                     setFormData({
@@ -106,13 +103,13 @@ export function Profile() {
                       shipping_address: e.target.value,
                     })
                   }
-                  placeholder="123 Rue Principale, Appt 4B"
+                  placeholder={t("profile.delivery.addressPlaceholder")}
                   id="shipping_address"
                 />
 
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                   <Input
-                    label="Ville"
+                    label={t("profile.delivery.city")}
                     value={formData.shipping_city}
                     onChange={(e) =>
                       setFormData({
@@ -120,12 +117,12 @@ export function Profile() {
                         shipping_city: e.target.value,
                       })
                     }
-                    placeholder="Paris"
+                    placeholder={t("profile.delivery.cityPlaceholder")}
                     id="shipping_city"
                   />
 
                   <Input
-                    label="Code postal"
+                    label={t("profile.delivery.postalCode")}
                     value={formData.shipping_postal_code}
                     onChange={(e) =>
                       setFormData({
@@ -133,7 +130,7 @@ export function Profile() {
                         shipping_postal_code: e.target.value,
                       })
                     }
-                    placeholder="75001"
+                    placeholder={t("profile.delivery.postalCodePlaceholder")}
                     id="shipping_postal_code"
                   />
 
@@ -142,7 +139,7 @@ export function Profile() {
                       htmlFor="shipping_country"
                       className="block text-sm font-medium text-foreground mb-3"
                     >
-                      Pays
+                      {t("profile.delivery.country")}
                     </label>
                     <select
                       id="shipping_country"
@@ -155,14 +152,14 @@ export function Profile() {
                       }
                       className="w-full bg-card/50 border border-border/50 rounded-2xl px-4 py-3 text-foreground focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all duration-300"
                     >
-                      <option value="">Sélectionner un pays</option>
-                      <option value="France">France</option>
-                      <option value="United States">États-Unis</option>
-                      <option value="Canada">Canada</option>
-                      <option value="United Kingdom">Royaume-Uni</option>
-                      <option value="Germany">Allemagne</option>
-                      <option value="Japan">Japon</option>
-                      <option value="Australia">Australie</option>
+                      <option value="">{t("profile.delivery.selectCountry")}</option>
+                      <option value="France">{t("profile.countries.france")}</option>
+                      <option value="United States">{t("profile.countries.unitedStates")}</option>
+                      <option value="Canada">{t("profile.countries.canada")}</option>
+                      <option value="United Kingdom">{t("profile.countries.unitedKingdom")}</option>
+                      <option value="Germany">{t("profile.countries.germany")}</option>
+                      <option value="Japan">{t("profile.countries.japan")}</option>
+                      <option value="Australia">{t("profile.countries.australia")}</option>
                     </select>
                   </div>
                 </div>
@@ -173,27 +170,27 @@ export function Profile() {
             <div className="space-y-6">
               <h3 className="text-lg font-medium text-foreground flex items-center">
                 <Edit3 className="h-5 w-5 mr-2 text-primary" />
-                Informations personnelles
+                {t("profile.personal.title")}
               </h3>
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <Input
-                  label="Nom d'affichage"
+                  label={t("profile.personal.displayName")}
                   value={formData.display_name}
                   onChange={(e) =>
                     setFormData({ ...formData, display_name: e.target.value })
                   }
-                  placeholder="Votre nom d'affichage"
+                  placeholder={t("profile.personal.displayNamePlaceholder")}
                   id="display_name"
                 />
 
                 <div>
-                  <label
-                    htmlFor="country"
-                    className="block text-sm font-medium text-foreground mb-3"
-                  >
-                    Pays
-                  </label>
+                    <label
+                      htmlFor="country"
+                      className="block text-sm font-medium text-foreground mb-3"
+                    >
+                      {t("profile.delivery.country")}
+                    </label>
                   <select
                     id="country"
                     value={formData.country}
@@ -202,14 +199,14 @@ export function Profile() {
                     }
                     className="w-full bg-card/50 border border-border/50 rounded-2xl px-4 py-3 text-foreground focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all duration-300"
                   >
-                    <option value="">Sélectionner un pays</option>
-                    <option value="France">France</option>
-                    <option value="United States">États-Unis</option>
-                    <option value="Canada">Canada</option>
-                    <option value="United Kingdom">Royaume-Uni</option>
-                    <option value="Germany">Allemagne</option>
-                    <option value="Japan">Japon</option>
-                    <option value="Australia">Australie</option>
+                    <option value="">{t("profile.delivery.selectCountry")}</option>
+                    <option value="France">{t("profile.countries.france")}</option>
+                    <option value="United States">{t("profile.countries.unitedStates")}</option>
+                    <option value="Canada">{t("profile.countries.canada")}</option>
+                    <option value="United Kingdom">{t("profile.countries.unitedKingdom")}</option>
+                    <option value="Germany">{t("profile.countries.germany")}</option>
+                    <option value="Japan">{t("profile.countries.japan")}</option>
+                    <option value="Australia">{t("profile.countries.australia")}</option>
                   </select>
                 </div>
               </div>
@@ -219,7 +216,7 @@ export function Profile() {
                   htmlFor="bio"
                   className="block text-sm font-medium text-foreground mb-3"
                 >
-                  Biographie
+                  {t("profile.personal.bio")}
                 </label>
                 <textarea
                   id="bio"
@@ -229,7 +226,7 @@ export function Profile() {
                     setFormData({ ...formData, bio: e.target.value })
                   }
                   className="w-full bg-card/50 border border-border/50 rounded-2xl px-4 py-3 text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all duration-300"
-                  placeholder="Parlez-nous de vous..."
+                  placeholder={t("profile.personal.bioPlaceholder")}
                 />
               </div>
             </div>
@@ -243,7 +240,7 @@ export function Profile() {
                 loading={saving}
                 className="px-8 py-3 text-base font-medium"
               >
-                {saving ? "Sauvegarde..." : "Sauvegarder dans mon profil"}
+                {saving ? t("profile.saving") : t("profile.save")}
               </Button>
             </div>
           </form>

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Filter, X, Grid, List, Search as SearchIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import supabase from "../lib/supabase";
 import { useCategories } from "../hooks/useCategories";
 import { ProductCard } from "../components/Cards/ProductCard";
@@ -26,6 +27,8 @@ export function Search() {
     country: searchParams.get("country") || "",
     sortBy: searchParams.get("sortBy") || "created_at",
   });
+
+  const { t } = useTranslation();
 
   useEffect(() => {
     searchItems();
@@ -215,15 +218,13 @@ export function Search() {
             <div>
               <h1 className="text-3xl md:text-4xl font-light text-foreground tracking-tight mb-2">
                 {filters.query
-                  ? `Résultats pour "${filters.query}"`
-                  : "Parcourir les Boutiques"}
+                  ? t("search.resultsFor", { query: filters.query })
+                  : t("search.browse")}
               </h1>
               <p className="text-muted-foreground/70 text-lg">
                 {loading
-                  ? "Recherche en cours..."
-                  : `${items.length} ${
-                      items.length === 1 ? "résultat" : "résultats"
-                    } trouvé${items.length > 1 ? "s" : ""}`}
+                  ? t("search.loading")
+                  : t("search.resultsCount", { count: items.length })}
               </p>
             </div>
 
@@ -234,7 +235,7 @@ export function Search() {
                 icon={Grid}
                 onClick={() => setViewMode("grid")}
               >
-                Grille
+                {t("search.view.grid")}
               </Button>
               <Button
                 variant={viewMode === "categories" ? "primary" : "outline"}
@@ -242,7 +243,7 @@ export function Search() {
                 icon={List}
                 onClick={() => setViewMode("categories")}
               >
-                Catégories
+                {t("search.view.categories")}
               </Button>
             </div>
           </div>
@@ -255,7 +256,7 @@ export function Search() {
             onClick={() => setShowFilters(!showFilters)}
             className="w-full lg:w-auto"
           >
-            {showFilters ? "Masquer les filtres" : "Afficher les filtres"}
+            {showFilters ? t("search.filters.hide") : t("search.filters.show")}
           </Button>
         </div>
 
@@ -263,14 +264,14 @@ export function Search() {
         {showFilters && (
           <div className="glass rounded-3xl p-6 md:p-8 border border-border/30 mb-8">
             <div className="flex items-center justify-between mb-6">
-              <h3 className="text-xl font-light text-foreground">Filtres</h3>
+              <h3 className="text-xl font-light text-foreground">{t("search.filters.title")}</h3>
               <Button
                 variant="ghost"
                 size="sm"
                 onClick={clearFilters}
                 className="text-primary hover:text-primary/80"
               >
-                Effacer tout
+                {t("search.filters.clear")}
               </Button>
             </div>
 
@@ -278,30 +279,30 @@ export function Search() {
               {/* Item Type */}
               <div>
                 <label className="block text-sm font-medium text-foreground mb-3">
-                  Type
+                  {t("search.filters.type.label")}
                 </label>
                 <select
                   value={filters.type}
                   onChange={(e) => updateFilter("type", e.target.value)}
                   className="w-full bg-card/50 border border-border/50 rounded-2xl px-4 py-3 text-foreground focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all duration-300"
                 >
-                  <option value="all">Tous les éléments</option>
-                  <option value="product">Produits</option>
-                  <option value="service">Artisans</option>
+                  <option value="all">{t("search.filters.type.all")}</option>
+                  <option value="product">{t("search.filters.type.product")}</option>
+                  <option value="service">{t("search.filters.type.service")}</option>
                 </select>
               </div>
 
               {/* Category */}
               <div>
                 <label className="block text-sm font-medium text-foreground mb-3">
-                  Catégorie
+                  {t("search.filters.category.label")}
                 </label>
                 <select
                   value={filters.category}
                   onChange={(e) => updateFilter("category", e.target.value)}
                   className="w-full bg-card/50 border border-border/50 rounded-2xl px-4 py-3 text-foreground focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all duration-300"
                 >
-                  <option value="">Toutes les catégories</option>
+                  <option value="">{t("search.filters.category.all")}</option>
                   {categories?.map((category) => (
                     <option key={category.id} value={category.name}>
                       {category.name}
@@ -313,19 +314,19 @@ export function Search() {
               {/* Price Range */}
               <div>
                 <label className="block text-sm font-medium text-foreground mb-3">
-                  Fourchette de prix
+                  {t("search.filters.price.label")}
                 </label>
                 <div className="flex gap-3">
                   <Input
                     type="number"
-                    placeholder="Min"
+                    placeholder={t("search.filters.price.min")}
                     value={filters.minPrice}
                     onChange={(e) => updateFilter("minPrice", e.target.value)}
                     className="flex-1"
                   />
                   <Input
                     type="number"
-                    placeholder="Max"
+                    placeholder={t("search.filters.price.max")}
                     value={filters.maxPrice}
                     onChange={(e) => updateFilter("maxPrice", e.target.value)}
                     className="flex-1"
@@ -336,16 +337,16 @@ export function Search() {
               {/* Sort */}
               <div>
                 <label className="block text-sm font-medium text-foreground mb-3">
-                  Trier par
+                  {t("search.filters.sort.label")}
                 </label>
                 <select
                   value={filters.sortBy}
                   onChange={(e) => updateFilter("sortBy", e.target.value)}
                   className="w-full bg-card/50 border border-border/50 rounded-2xl px-4 py-3 text-foreground focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all duration-300"
                 >
-                  <option value="created_at">Plus récent</option>
-                  <option value="price_low">Prix : Croissant</option>
-                  <option value="price_high">Prix : Décroissant</option>
+                  <option value="created_at">{t("search.filters.sort.newest")}</option>
+                  <option value="price_low">{t("search.filters.sort.priceAsc")}</option>
+                  <option value="price_high">{t("search.filters.sort.priceDesc")}</option>
                 </select>
               </div>
             </div>
@@ -371,7 +372,7 @@ export function Search() {
                 <div className="glass rounded-3xl p-12 border border-border/30">
                   <SearchIcon className="h-16 w-16 text-muted-foreground/40 mx-auto mb-4" />
                   <p className="text-muted-foreground/70 text-lg">
-                    Aucun élément trouvé correspondant à vos critères.
+                    {t("search.noResults")}
                   </p>
                 </div>
               </div>
@@ -387,8 +388,7 @@ export function Search() {
                       {categoryName}
                     </h2>
                     <span className="text-muted-foreground/60 text-sm">
-                      {categoryItems.length} élément
-                      {categoryItems.length > 1 ? "s" : ""}
+                      {t("search.categoryCount", { count: categoryItems.length })}
                     </span>
                   </div>
 
@@ -410,7 +410,7 @@ export function Search() {
                 <div className="glass rounded-3xl p-12 border border-border/30">
                   <SearchIcon className="h-16 w-16 text-muted-foreground/40 mx-auto mb-4" />
                   <p className="text-muted-foreground/70 text-lg">
-                    Aucun élément trouvé correspondant à vos critères.
+                    {t("search.noResults")}
                   </p>
                 </div>
               </div>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -18,7 +18,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- localize shipping manager with translated form labels, actions, and help text
- internationalize stock info card, notification panel, and creator profile with i18n keys
- expand English and French locale files for creator tools and notifications
- internationalize admin dashboard with translation keys and localized quick actions

## Testing
- `npm test`
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_68ba4feba53c83268c946aed4be57006